### PR TITLE
fix: only trigger reorg on actual conflicts, not generic errors

### DIFF
--- a/op-interop-filter/filter/chain_ingester.go
+++ b/op-interop-filter/filter/chain_ingester.go
@@ -354,14 +354,10 @@ func (c *ChainIngester) catchUp() error {
 	}
 
 	// Step 4: Backfill to head
-	if err := c.backfill(startBlock, head.NumberU64()); err != nil {
-		if !errors.Is(err, context.Canceled) {
-			c.triggerReorg()
-		}
-		return err
-	}
-
-	return nil
+	// Note: reorg detection happens inside ingestBlock via parent hash mismatch
+	// and inside processBlockLogs via ErrConflict - we don't trigger reorg on
+	// generic errors like RPC failures
+	return c.backfill(startBlock, head.NumberU64())
 }
 
 // determineStartBlock figures out where to start ingestion.


### PR DESCRIPTION
## Summary
Previously, any backfill error (including RPC failures) would trigger the failsafe reorg callback. This was incorrect because transient errors like network timeouts are not reorgs.

## Changes
Reorg detection now only happens on actual conflicts:
- Parent hash mismatch in `ingestBlock` (line 536-543)
- `ErrConflict` in `processBlockLogs` (lines 608-610, 620-622)

Generic errors like RPC failures just return the error without triggering failsafe.

## Test plan
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)