### PR TITLE
feat(op-service): add depset package for interop dependency set management

### DIFF
--- a/op-service/depset/depset_test.go
+++ b/op-service/depset/depset_test.go
@@ -487,3 +487,104 @@ func TestNewValidatedTemporalDependencySet_Invalid(t *testing.T) {
 	_, err := NewValidatedTemporalDependencySet(cfg)
 	require.Error(t, err)
 }
+
+// --- Interop Time Validation Tests ---
+
+func TestValidateInteropTimeMatch_Valid(t *testing.T) {
+	cfg := &ChainDependencyConfigWithInteropTime{
+		ChainDependencyConfig: ChainDependencyConfig{
+			ChainID: chainID(1),
+			DependencyUpdates: []DependencyUpdate{
+				{Timestamp: 1000, Dependencies: []eth.ChainID{chainID(2)}},
+				{Timestamp: 2000, Dependencies: []eth.ChainID{chainID(2), chainID(3)}},
+			},
+		},
+		InteropTime: 1000, // Matches first dependency_updates timestamp
+	}
+
+	err := ValidateInteropTimeMatch(cfg)
+	require.NoError(t, err)
+}
+
+func TestValidateInteropTimeMatch_Mismatch(t *testing.T) {
+	cfg := &ChainDependencyConfigWithInteropTime{
+		ChainDependencyConfig: ChainDependencyConfig{
+			ChainID: chainID(1),
+			DependencyUpdates: []DependencyUpdate{
+				{Timestamp: 1000, Dependencies: []eth.ChainID{chainID(2)}},
+			},
+		},
+		InteropTime: 500, // Does NOT match first dependency_updates timestamp
+	}
+
+	err := ValidateInteropTimeMatch(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must match interop_time")
+}
+
+func TestValidateInteropTimeMatch_NoDependencyUpdates(t *testing.T) {
+	cfg := &ChainDependencyConfigWithInteropTime{
+		ChainDependencyConfig: ChainDependencyConfig{
+			ChainID:           chainID(1),
+			DependencyUpdates: []DependencyUpdate{}, // Empty!
+		},
+		InteropTime: 1000,
+	}
+
+	err := ValidateInteropTimeMatch(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no dependency_updates")
+}
+
+func TestValidateAllInteropTimes(t *testing.T) {
+	configs := []ChainDependencyConfigWithInteropTime{
+		{
+			ChainDependencyConfig: ChainDependencyConfig{
+				ChainID: chainID(1),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 1000, Dependencies: []eth.ChainID{chainID(2)}},
+				},
+			},
+			InteropTime: 1000, // Valid
+		},
+		{
+			ChainDependencyConfig: ChainDependencyConfig{
+				ChainID: chainID(2),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 1000, Dependencies: []eth.ChainID{}},
+				},
+			},
+			InteropTime: 1000, // Valid
+		},
+	}
+
+	err := ValidateAllInteropTimes(configs)
+	require.NoError(t, err)
+}
+
+func TestValidateAllInteropTimes_OneMismatch(t *testing.T) {
+	configs := []ChainDependencyConfigWithInteropTime{
+		{
+			ChainDependencyConfig: ChainDependencyConfig{
+				ChainID: chainID(1),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 1000, Dependencies: []eth.ChainID{chainID(2)}},
+				},
+			},
+			InteropTime: 1000, // Valid
+		},
+		{
+			ChainDependencyConfig: ChainDependencyConfig{
+				ChainID: chainID(2),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 2000, Dependencies: []eth.ChainID{}},
+				},
+			},
+			InteropTime: 1000, // Mismatch!
+		},
+	}
+
+	err := ValidateAllInteropTimes(configs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must match interop_time")
+}

--- a/op-service/depset/depset_test.go
+++ b/op-service/depset/depset_test.go
@@ -1,0 +1,489 @@
+package depset
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/require"
+)
+
+// Helper to create ChainID from uint64
+func chainID(id uint64) eth.ChainID {
+	return eth.ChainIDFromUInt64(id)
+}
+
+// --- Graph Tests ---
+
+func TestDependencyGraph_Basic(t *testing.T) {
+	g := NewDependencyGraph(1000)
+
+	// Add chains
+	g.AddChain(chainID(1))
+	g.AddChain(chainID(2))
+	g.AddChain(chainID(3))
+
+	require.True(t, g.HasChain(chainID(1)))
+	require.True(t, g.HasChain(chainID(2)))
+	require.True(t, g.HasChain(chainID(3)))
+	require.False(t, g.HasChain(chainID(4)))
+
+	require.Equal(t, 3, g.NumChains())
+	require.Equal(t, uint64(1000), g.Timestamp())
+}
+
+func TestDependencyGraph_Dependencies(t *testing.T) {
+	g := NewDependencyGraph(1000)
+
+	// Chain 1 depends on 2 and 3
+	g.SetDependencies(chainID(1), []eth.ChainID{chainID(2), chainID(3)})
+
+	deps := g.Dependencies(chainID(1))
+	require.Len(t, deps, 2)
+	require.True(t, g.HasDependency(chainID(1), chainID(2)))
+	require.True(t, g.HasDependency(chainID(1), chainID(3)))
+	require.False(t, g.HasDependency(chainID(1), chainID(4)))
+
+	// Chain 2 has no dependencies
+	require.Empty(t, g.Dependencies(chainID(2)))
+}
+
+func TestBuildGraphAt(t *testing.T) {
+	cfg := &TemporalDependencyConfig{
+		Chains: []ChainDependencyConfig{
+			{
+				ChainID: chainID(1),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{chainID(2)}},
+					{Timestamp: 200, Dependencies: []eth.ChainID{chainID(2), chainID(3)}},
+				},
+			},
+			{
+				ChainID: chainID(2),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{}},
+				},
+			},
+			{
+				ChainID: chainID(3),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 150, Dependencies: []eth.ChainID{}},
+				},
+			},
+		},
+	}
+
+	// At timestamp 50 (before any updates)
+	g50 := BuildGraphAt(cfg, 50)
+	require.Empty(t, g50.Dependencies(chainID(1)))
+
+	// At timestamp 100
+	g100 := BuildGraphAt(cfg, 100)
+	deps := g100.Dependencies(chainID(1))
+	require.Len(t, deps, 1)
+	require.Equal(t, chainID(2), deps[0])
+
+	// At timestamp 200
+	g200 := BuildGraphAt(cfg, 200)
+	deps = g200.Dependencies(chainID(1))
+	require.Len(t, deps, 2)
+}
+
+// --- Transitive Closure Tests ---
+
+func TestTransitiveClosure_Simple(t *testing.T) {
+	// A -> B -> C
+	g := NewDependencyGraph(1000)
+	g.SetDependencies(chainID(1), []eth.ChainID{chainID(2)})
+	g.SetDependencies(chainID(2), []eth.ChainID{chainID(3)})
+	g.AddChain(chainID(3))
+
+	// Transitive closure of A should be [B, C]
+	closure := TransitiveClosure(g, chainID(1))
+	require.Len(t, closure, 2)
+	require.Contains(t, closure, chainID(2))
+	require.Contains(t, closure, chainID(3))
+
+	// Transitive closure of B should be [C]
+	closure = TransitiveClosure(g, chainID(2))
+	require.Len(t, closure, 1)
+	require.Equal(t, chainID(3), closure[0])
+
+	// Transitive closure of C should be empty
+	closure = TransitiveClosure(g, chainID(3))
+	require.Empty(t, closure)
+}
+
+func TestTransitiveClosure_Diamond(t *testing.T) {
+	//     A
+	//    / \
+	//   B   C
+	//    \ /
+	//     D
+	g := NewDependencyGraph(1000)
+	g.SetDependencies(chainID(1), []eth.ChainID{chainID(2), chainID(3)})
+	g.SetDependencies(chainID(2), []eth.ChainID{chainID(4)})
+	g.SetDependencies(chainID(3), []eth.ChainID{chainID(4)})
+	g.AddChain(chainID(4))
+
+	closure := TransitiveClosure(g, chainID(1))
+	require.Len(t, closure, 3) // B, C, D
+	require.Contains(t, closure, chainID(2))
+	require.Contains(t, closure, chainID(3))
+	require.Contains(t, closure, chainID(4))
+}
+
+func TestTransitiveClosure_Cycle(t *testing.T) {
+	// A -> B -> C -> A (cycle)
+	g := NewDependencyGraph(1000)
+	g.SetDependencies(chainID(1), []eth.ChainID{chainID(2)})
+	g.SetDependencies(chainID(2), []eth.ChainID{chainID(3)})
+	g.SetDependencies(chainID(3), []eth.ChainID{chainID(1)})
+
+	// All chains should reach all others
+	closure := TransitiveClosure(g, chainID(1))
+	require.Len(t, closure, 2) // B, C (not including self)
+	require.Contains(t, closure, chainID(2))
+	require.Contains(t, closure, chainID(3))
+}
+
+func TestMissingTransitiveDependencies(t *testing.T) {
+	// A declares [B] but B depends on C
+	// So A is missing transitive dependency on C
+	g := NewDependencyGraph(1000)
+	g.SetDependencies(chainID(1), []eth.ChainID{chainID(2)})
+	g.SetDependencies(chainID(2), []eth.ChainID{chainID(3)})
+	g.AddChain(chainID(3))
+
+	missing := MissingTransitiveDependencies(g, chainID(1))
+	require.Len(t, missing, 1)
+	require.Equal(t, chainID(3), missing[0])
+
+	// B is not missing any (declares nothing, needs nothing transitively not declared)
+	// Actually B declares [C], so it has C transitively but also declares C
+	// Wait, B declares [3] and 3 has no deps, so B's transitive is just [3] which it declares
+	missing = MissingTransitiveDependencies(g, chainID(2))
+	require.Empty(t, missing)
+}
+
+// --- Validation Tests ---
+
+func TestValidate_ValidConfig(t *testing.T) {
+	// A depends on B and C, B depends on C
+	// A explicitly declares both B and C - valid!
+	cfg := &TemporalDependencyConfig{
+		Chains: []ChainDependencyConfig{
+			{
+				ChainID: chainID(1),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{chainID(2), chainID(3)}},
+				},
+			},
+			{
+				ChainID: chainID(2),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{chainID(3)}},
+				},
+			},
+			{
+				ChainID: chainID(3),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{}},
+				},
+			},
+		},
+	}
+
+	err := Validate(cfg)
+	require.NoError(t, err)
+}
+
+func TestValidate_MissingTransitiveDep(t *testing.T) {
+	// A depends on B, B depends on C
+	// A does NOT declare C - invalid!
+	cfg := &TemporalDependencyConfig{
+		Chains: []ChainDependencyConfig{
+			{
+				ChainID: chainID(1),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{chainID(2)}}, // Missing chainID(3)!
+				},
+			},
+			{
+				ChainID: chainID(2),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{chainID(3)}},
+				},
+			},
+			{
+				ChainID: chainID(3),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{}},
+				},
+			},
+		},
+	}
+
+	err := Validate(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing transitive dependencies")
+}
+
+func TestValidate_SelfDependency(t *testing.T) {
+	cfg := &TemporalDependencyConfig{
+		Chains: []ChainDependencyConfig{
+			{
+				ChainID: chainID(1),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{chainID(1)}}, // Self-dependency!
+				},
+			},
+		},
+	}
+
+	err := Validate(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot depend on itself")
+}
+
+func TestValidate_DuplicateChain(t *testing.T) {
+	cfg := &TemporalDependencyConfig{
+		Chains: []ChainDependencyConfig{
+			{
+				ChainID: chainID(1),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{}},
+				},
+			},
+			{
+				ChainID: chainID(1), // Duplicate!
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 200, Dependencies: []eth.ChainID{}},
+				},
+			},
+		},
+	}
+
+	err := Validate(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate chain definition")
+}
+
+func TestValidate_NonIncreasingTimestamps(t *testing.T) {
+	cfg := &TemporalDependencyConfig{
+		Chains: []ChainDependencyConfig{
+			{
+				ChainID: chainID(1),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 200, Dependencies: []eth.ChainID{}},
+					{Timestamp: 100, Dependencies: []eth.ChainID{}}, // Out of order!
+				},
+			},
+		},
+	}
+
+	err := Validate(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "strictly increasing timestamps")
+}
+
+// --- SCC Tests ---
+
+func TestComputeSCCs_NoCycle(t *testing.T) {
+	// A -> B -> C (no cycle)
+	g := NewDependencyGraph(1000)
+	g.SetDependencies(chainID(1), []eth.ChainID{chainID(2)})
+	g.SetDependencies(chainID(2), []eth.ChainID{chainID(3)})
+	g.AddChain(chainID(3))
+
+	sccs := ComputeSCCs(g)
+	require.Len(t, sccs, 3) // Each chain is its own SCC
+
+	// All SCCs should be trivial (size 1, no self-loop)
+	for _, scc := range sccs {
+		require.True(t, scc.IsTrivial(g))
+	}
+}
+
+func TestComputeSCCs_SimpleCycle(t *testing.T) {
+	// A -> B -> A (cycle)
+	g := NewDependencyGraph(1000)
+	g.SetDependencies(chainID(1), []eth.ChainID{chainID(2)})
+	g.SetDependencies(chainID(2), []eth.ChainID{chainID(1)})
+
+	sccs := ComputeSCCs(g)
+	require.Len(t, sccs, 1) // Both chains in same SCC
+
+	scc := sccs[0]
+	require.Len(t, scc.Chains, 2)
+	require.True(t, scc.Contains(chainID(1)))
+	require.True(t, scc.Contains(chainID(2)))
+	require.False(t, scc.IsTrivial(g))
+}
+
+func TestComputeSCCs_TwoCycles(t *testing.T) {
+	// A <-> B and C <-> D (two separate cycles)
+	g := NewDependencyGraph(1000)
+	g.SetDependencies(chainID(1), []eth.ChainID{chainID(2)})
+	g.SetDependencies(chainID(2), []eth.ChainID{chainID(1)})
+	g.SetDependencies(chainID(3), []eth.ChainID{chainID(4)})
+	g.SetDependencies(chainID(4), []eth.ChainID{chainID(3)})
+
+	sccs := ComputeSCCs(g)
+	require.Len(t, sccs, 2) // Two SCCs
+
+	// Both SCCs should have 2 chains
+	for _, scc := range sccs {
+		require.Len(t, scc.Chains, 2)
+		require.False(t, scc.IsTrivial(g))
+	}
+}
+
+// --- Interop Set Tests ---
+
+func TestDeriveInteropSets_MutualDependency(t *testing.T) {
+	// A <-> B (mutual dependency = interop set)
+	g := NewDependencyGraph(1000)
+	g.SetDependencies(chainID(1), []eth.ChainID{chainID(2)})
+	g.SetDependencies(chainID(2), []eth.ChainID{chainID(1)})
+
+	sets := DeriveInteropSets(g)
+	require.Len(t, sets, 1)
+
+	is := sets[0]
+	require.Len(t, is.Chains, 2)
+	require.True(t, is.Contains(chainID(1)))
+	require.True(t, is.Contains(chainID(2)))
+}
+
+func TestDeriveInteropSets_NoMutualDependency(t *testing.T) {
+	// A -> B (one-way = no interop set)
+	g := NewDependencyGraph(1000)
+	g.SetDependencies(chainID(1), []eth.ChainID{chainID(2)})
+	g.AddChain(chainID(2))
+
+	sets := DeriveInteropSets(g)
+	require.Empty(t, sets) // No interop sets
+}
+
+func TestFindInteropSet(t *testing.T) {
+	// A <-> B, C alone
+	g := NewDependencyGraph(1000)
+	g.SetDependencies(chainID(1), []eth.ChainID{chainID(2)})
+	g.SetDependencies(chainID(2), []eth.ChainID{chainID(1)})
+	g.AddChain(chainID(3))
+
+	// A is in an interop set
+	is := FindInteropSet(g, chainID(1))
+	require.NotNil(t, is)
+	require.True(t, is.Contains(chainID(1)))
+	require.True(t, is.Contains(chainID(2)))
+
+	// C is not in any interop set
+	is = FindInteropSet(g, chainID(3))
+	require.Nil(t, is)
+}
+
+// --- Temporal Tests ---
+
+func TestTemporalDependencySet_DependenciesAt(t *testing.T) {
+	cfg := &TemporalDependencyConfig{
+		Chains: []ChainDependencyConfig{
+			{
+				ChainID: chainID(1),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{chainID(2)}},
+					{Timestamp: 200, Dependencies: []eth.ChainID{chainID(2), chainID(3)}},
+				},
+			},
+			{
+				ChainID: chainID(2),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{}},
+				},
+			},
+			{
+				ChainID: chainID(3),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{}},
+				},
+			},
+		},
+	}
+
+	tds := NewTemporalDependencySet(cfg)
+
+	// At timestamp 50 (before any updates)
+	deps := tds.DependenciesAt(chainID(1), 50)
+	require.Empty(t, deps)
+
+	// At timestamp 150
+	deps = tds.DependenciesAt(chainID(1), 150)
+	require.Len(t, deps, 1)
+	require.Equal(t, chainID(2), deps[0])
+
+	// At timestamp 250
+	deps = tds.DependenciesAt(chainID(1), 250)
+	require.Len(t, deps, 2)
+}
+
+func TestTemporalDependencySet_InteropSetAt(t *testing.T) {
+	// At t=100: A -> B (no interop set)
+	// At t=200: A <-> B (interop set!)
+	cfg := &TemporalDependencyConfig{
+		Chains: []ChainDependencyConfig{
+			{
+				ChainID: chainID(1),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{chainID(2)}},
+				},
+			},
+			{
+				ChainID: chainID(2),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{}},
+					{Timestamp: 200, Dependencies: []eth.ChainID{chainID(1)}},
+				},
+			},
+		},
+	}
+
+	tds := NewTemporalDependencySet(cfg)
+
+	// At t=150: A -> B (one-way, no interop set)
+	is := tds.InteropSetAt(chainID(1), 150)
+	require.Nil(t, is)
+
+	// At t=250: A <-> B (mutual, interop set!)
+	is = tds.InteropSetAt(chainID(1), 250)
+	require.NotNil(t, is)
+	require.Len(t, is, 2)
+}
+
+func TestNewValidatedTemporalDependencySet_Invalid(t *testing.T) {
+	// Invalid: A -> B -> C but A only declares B
+	cfg := &TemporalDependencyConfig{
+		Chains: []ChainDependencyConfig{
+			{
+				ChainID: chainID(1),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{chainID(2)}},
+				},
+			},
+			{
+				ChainID: chainID(2),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{chainID(3)}},
+				},
+			},
+			{
+				ChainID: chainID(3),
+				DependencyUpdates: []DependencyUpdate{
+					{Timestamp: 100, Dependencies: []eth.ChainID{}},
+				},
+			},
+		},
+	}
+
+	_, err := NewValidatedTemporalDependencySet(cfg)
+	require.Error(t, err)
+}

--- a/op-service/depset/doc.go
+++ b/op-service/depset/doc.go
@@ -1,0 +1,16 @@
+// Package depset provides utilities for managing and validating interop dependency sets.
+//
+// Each chain in the interop protocol specifies a dependency set: the set of other chains
+// whose state it is allowed to read. Dependencies are logically transitive (if A depends
+// on B and B depends on C, then A implicitly depends on C), but the configuration requires
+// all dependencies to be explicitly declared.
+//
+// This package provides:
+//   - Temporal dependency configuration with timestamped updates (DSO forks)
+//   - Validation that all transitive dependencies are explicitly declared
+//   - Interop set computation (strongly connected components of mutual dependencies)
+//   - Dependency graph operations and queries
+//
+// The package is designed to be used by services like op-interop-filter, supernode,
+// and other components that need to understand chain dependency relationships.
+package depset

--- a/op-service/depset/graph.go
+++ b/op-service/depset/graph.go
@@ -1,0 +1,138 @@
+package depset
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// DependencyGraph represents the dependency relationships at a specific timestamp.
+// This is an immutable snapshot of the dependency graph at time T.
+//
+// In the graph, an edge from A to B means "A depends on B" (A can read B's state).
+type DependencyGraph struct {
+	// adjacency maps each chain to its direct dependencies.
+	adjacency map[eth.ChainID][]eth.ChainID
+
+	// chains is the set of all chains in the graph.
+	chains map[eth.ChainID]struct{}
+
+	// timestamp is the point in time this graph represents.
+	timestamp uint64
+}
+
+// NewDependencyGraph creates a new empty dependency graph for the given timestamp.
+func NewDependencyGraph(timestamp uint64) *DependencyGraph {
+	return &DependencyGraph{
+		adjacency: make(map[eth.ChainID][]eth.ChainID),
+		chains:    make(map[eth.ChainID]struct{}),
+		timestamp: timestamp,
+	}
+}
+
+// AddChain adds a chain to the graph without any dependencies.
+func (g *DependencyGraph) AddChain(chainID eth.ChainID) {
+	g.chains[chainID] = struct{}{}
+	if _, exists := g.adjacency[chainID]; !exists {
+		g.adjacency[chainID] = nil
+	}
+}
+
+// SetDependencies sets the dependencies for a chain, replacing any existing dependencies.
+func (g *DependencyGraph) SetDependencies(chainID eth.ChainID, deps []eth.ChainID) {
+	g.chains[chainID] = struct{}{}
+	g.adjacency[chainID] = make([]eth.ChainID, len(deps))
+	copy(g.adjacency[chainID], deps)
+
+	// Also ensure all dependency chains are in the graph
+	for _, dep := range deps {
+		g.chains[dep] = struct{}{}
+		if _, exists := g.adjacency[dep]; !exists {
+			g.adjacency[dep] = nil
+		}
+	}
+}
+
+// Dependencies returns the direct dependencies of a chain.
+// Returns nil if the chain is not in the graph.
+func (g *DependencyGraph) Dependencies(chainID eth.ChainID) []eth.ChainID {
+	deps, exists := g.adjacency[chainID]
+	if !exists {
+		return nil
+	}
+	// Return a copy to prevent mutation
+	result := make([]eth.ChainID, len(deps))
+	copy(result, deps)
+	return result
+}
+
+// Chains returns all chains in the graph, sorted by chain ID.
+func (g *DependencyGraph) Chains() []eth.ChainID {
+	result := make([]eth.ChainID, 0, len(g.chains))
+	for chainID := range g.chains {
+		result = append(result, chainID)
+	}
+	eth.SortChainID(result)
+	return result
+}
+
+// HasChain returns true if the chain is in the graph.
+func (g *DependencyGraph) HasChain(chainID eth.ChainID) bool {
+	_, exists := g.chains[chainID]
+	return exists
+}
+
+// HasDependency returns true if 'from' has 'to' as a direct dependency.
+func (g *DependencyGraph) HasDependency(from, to eth.ChainID) bool {
+	deps := g.adjacency[from]
+	for _, dep := range deps {
+		if dep.Cmp(to) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// Timestamp returns the timestamp this graph represents.
+func (g *DependencyGraph) Timestamp() uint64 {
+	return g.timestamp
+}
+
+// NumChains returns the number of chains in the graph.
+func (g *DependencyGraph) NumChains() int {
+	return len(g.chains)
+}
+
+// NumEdges returns the total number of dependency edges in the graph.
+func (g *DependencyGraph) NumEdges() int {
+	count := 0
+	for _, deps := range g.adjacency {
+		count += len(deps)
+	}
+	return count
+}
+
+// BuildGraphAt builds a DependencyGraph from a TemporalDependencyConfig at the given timestamp.
+// For each chain, it finds the most recent DependencyUpdate with timestamp <= ts.
+func BuildGraphAt(cfg *TemporalDependencyConfig, ts uint64) *DependencyGraph {
+	g := NewDependencyGraph(ts)
+
+	for _, chainCfg := range cfg.Chains {
+		g.AddChain(chainCfg.ChainID)
+
+		// Find the most recent update at or before ts
+		var effectiveUpdate *DependencyUpdate
+		for i := range chainCfg.DependencyUpdates {
+			update := &chainCfg.DependencyUpdates[i]
+			if update.Timestamp <= ts {
+				effectiveUpdate = update
+			} else {
+				break // Updates are sorted, so we can stop
+			}
+		}
+
+		if effectiveUpdate != nil {
+			g.SetDependencies(chainCfg.ChainID, effectiveUpdate.Dependencies)
+		}
+	}
+
+	return g
+}

--- a/op-service/depset/interop_set.go
+++ b/op-service/depset/interop_set.go
@@ -1,0 +1,82 @@
+package depset
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// InteropSet represents a set of chains that can freely interoperate.
+// Chains in the same interop set form a strongly connected component,
+// meaning each chain can read from and write to every other chain in the set.
+type InteropSet struct {
+	// Chains in this interop set, sorted by chain ID for determinism.
+	Chains []eth.ChainID
+}
+
+// Size returns the number of chains in the interop set.
+func (is *InteropSet) Size() int {
+	return len(is.Chains)
+}
+
+// Contains returns true if the interop set contains the given chain.
+func (is *InteropSet) Contains(chainID eth.ChainID) bool {
+	for _, c := range is.Chains {
+		if c.Cmp(chainID) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// DeriveInteropSets derives interop sets from the SCCs of the dependency graph.
+// Only non-trivial SCCs (size > 1 or with self-dependency) are considered interop sets.
+// Single isolated chains without self-dependency are not interop sets because
+// there's no mutual interoperability.
+func DeriveInteropSets(g *DependencyGraph) []InteropSet {
+	sccs := ComputeSCCs(g)
+	interopSets := make([]InteropSet, 0)
+
+	for _, scc := range sccs {
+		// Skip trivial SCCs (single chain with no self-loop)
+		if scc.IsTrivial(g) {
+			continue
+		}
+
+		is := InteropSet{
+			Chains: make([]eth.ChainID, len(scc.Chains)),
+		}
+		copy(is.Chains, scc.Chains)
+		interopSets = append(interopSets, is)
+	}
+
+	return interopSets
+}
+
+// FindInteropSet finds the interop set containing the given chain.
+// Returns nil if the chain is not part of any interop set.
+func FindInteropSet(g *DependencyGraph, chainID eth.ChainID) *InteropSet {
+	interopSets := DeriveInteropSets(g)
+	for i := range interopSets {
+		if interopSets[i].Contains(chainID) {
+			return &interopSets[i]
+		}
+	}
+	return nil
+}
+
+// AllInteropSets returns all interop sets in the graph.
+// This is an alias for DeriveInteropSets for API clarity.
+func AllInteropSets(g *DependencyGraph) []InteropSet {
+	return DeriveInteropSets(g)
+}
+
+// InteropSetChains returns the chain IDs in the interop set containing the given chain.
+// Returns nil if the chain is not part of any interop set.
+func InteropSetChains(g *DependencyGraph, chainID eth.ChainID) []eth.ChainID {
+	is := FindInteropSet(g, chainID)
+	if is == nil {
+		return nil
+	}
+	result := make([]eth.ChainID, len(is.Chains))
+	copy(result, is.Chains)
+	return result
+}

--- a/op-service/depset/scc.go
+++ b/op-service/depset/scc.go
@@ -1,0 +1,113 @@
+package depset
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// SCC represents a Strongly Connected Component in the dependency graph.
+// An SCC is a maximal set of vertices where every vertex is reachable from every other vertex.
+type SCC struct {
+	// Chains in this SCC, sorted by chain ID for determinism.
+	Chains []eth.ChainID
+}
+
+// Size returns the number of chains in the SCC.
+func (s *SCC) Size() int {
+	return len(s.Chains)
+}
+
+// IsTrivial returns true if the SCC contains only one chain with no self-dependency.
+// Trivial SCCs are not considered interop sets because there's no mutual dependency.
+func (s *SCC) IsTrivial(g *DependencyGraph) bool {
+	if len(s.Chains) != 1 {
+		return false
+	}
+	// A single-node SCC is non-trivial only if there's a self-loop
+	return !g.HasDependency(s.Chains[0], s.Chains[0])
+}
+
+// Contains returns true if the SCC contains the given chain.
+func (s *SCC) Contains(chainID eth.ChainID) bool {
+	for _, c := range s.Chains {
+		if c.Cmp(chainID) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// tarjanState holds the state for a single node during Tarjan's algorithm.
+type tarjanState struct {
+	index   int
+	lowlink int
+	onStack bool
+}
+
+// ComputeSCCs computes all strongly connected components in the dependency graph
+// using Tarjan's algorithm. Returns SCCs in reverse topological order.
+//
+// Time complexity: O(V + E) where V is the number of chains and E is the number of edges.
+func ComputeSCCs(g *DependencyGraph) []SCC {
+	index := 0
+	stack := make([]eth.ChainID, 0)
+	state := make(map[eth.ChainID]*tarjanState)
+	sccs := make([]SCC, 0)
+
+	var strongconnect func(v eth.ChainID)
+	strongconnect = func(v eth.ChainID) {
+		// Set the depth index for v
+		state[v] = &tarjanState{
+			index:   index,
+			lowlink: index,
+			onStack: true,
+		}
+		index++
+		stack = append(stack, v)
+
+		// Consider successors of v
+		for _, w := range g.Dependencies(v) {
+			if state[w] == nil {
+				// Successor w has not yet been visited; recurse on it
+				strongconnect(w)
+				state[v].lowlink = min(state[v].lowlink, state[w].lowlink)
+			} else if state[w].onStack {
+				// Successor w is in the stack and hence in the current SCC
+				state[v].lowlink = min(state[v].lowlink, state[w].index)
+			}
+		}
+
+		// If v is a root node, pop the stack and generate an SCC
+		if state[v].lowlink == state[v].index {
+			scc := SCC{Chains: make([]eth.ChainID, 0)}
+			for {
+				w := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				state[w].onStack = false
+				scc.Chains = append(scc.Chains, w)
+				if w.Cmp(v) == 0 {
+					break
+				}
+			}
+			// Sort chains for determinism
+			eth.SortChainID(scc.Chains)
+			sccs = append(sccs, scc)
+		}
+	}
+
+	// Call strongconnect for each unvisited node
+	for _, v := range g.Chains() {
+		if state[v] == nil {
+			strongconnect(v)
+		}
+	}
+
+	return sccs
+}
+
+// min returns the minimum of two integers.
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/op-service/depset/temporal.go
+++ b/op-service/depset/temporal.go
@@ -1,0 +1,112 @@
+package depset
+
+import (
+	"sync"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// TemporalDependencySet provides temporal queries on a validated dependency configuration.
+// All methods are safe for concurrent use.
+type TemporalDependencySet interface {
+	// DependenciesAt returns the dependencies for a chain at a given timestamp.
+	// Returns nil if the chain has no dependencies at that time or doesn't exist.
+	DependenciesAt(chainID eth.ChainID, timestamp uint64) []eth.ChainID
+
+	// InteropSetAt returns the interop set (SCC) containing the chain at timestamp.
+	// Interop sets are strongly connected components - chains with mutual dependencies.
+	// Returns nil if the chain is not part of any interop set at the given time.
+	InteropSetAt(chainID eth.ChainID, timestamp uint64) []eth.ChainID
+
+	// GraphAt returns the full dependency graph snapshot at the given timestamp.
+	GraphAt(timestamp uint64) *DependencyGraph
+}
+
+// temporalDependencySet is the concrete implementation of TemporalDependencySet.
+type temporalDependencySet struct {
+	config *TemporalDependencyConfig
+
+	// chainSet contains all chains in the config for quick lookup.
+	chainSet map[eth.ChainID]struct{}
+
+	// sortedTimestamps is a sorted list of all activation timestamps.
+	sortedTimestamps []uint64
+
+	// graphCache caches computed graphs at specific timestamps.
+	graphCache sync.Map // map[uint64]*DependencyGraph
+}
+
+// NewTemporalDependencySet creates a new TemporalDependencySet from a validated config.
+// The config must have been validated with Validate() before calling this.
+// If validation hasn't been done, the behavior is undefined.
+func NewTemporalDependencySet(cfg *TemporalDependencyConfig) TemporalDependencySet {
+	impl := &temporalDependencySet{
+		config:   cfg,
+		chainSet: make(map[eth.ChainID]struct{}),
+	}
+
+	// Build chain set
+	for _, chain := range cfg.Chains {
+		impl.chainSet[chain.ChainID] = struct{}{}
+	}
+
+	// Get sorted timestamps
+	impl.sortedTimestamps = cfg.AllTimestamps()
+
+	return impl
+}
+
+// NewValidatedTemporalDependencySet creates a new TemporalDependencySet, validating first.
+// Returns an error if validation fails.
+func NewValidatedTemporalDependencySet(cfg *TemporalDependencyConfig) (TemporalDependencySet, error) {
+	if err := Validate(cfg); err != nil {
+		return nil, err
+	}
+	return NewTemporalDependencySet(cfg), nil
+}
+
+// DependenciesAt returns the dependencies for a chain at a given timestamp.
+func (t *temporalDependencySet) DependenciesAt(chainID eth.ChainID, timestamp uint64) []eth.ChainID {
+	g := t.GraphAt(timestamp)
+	return g.Dependencies(chainID)
+}
+
+// InteropSetAt returns the interop set containing the chain at the given timestamp.
+func (t *temporalDependencySet) InteropSetAt(chainID eth.ChainID, timestamp uint64) []eth.ChainID {
+	g := t.GraphAt(timestamp)
+	return InteropSetChains(g, chainID)
+}
+
+// GraphAt returns the dependency graph at the given timestamp.
+// Results are cached for efficiency.
+func (t *temporalDependencySet) GraphAt(timestamp uint64) *DependencyGraph {
+	// Check cache first
+	if cached, ok := t.graphCache.Load(timestamp); ok {
+		return cached.(*DependencyGraph)
+	}
+
+	// Build the graph
+	g := BuildGraphAt(t.config, timestamp)
+
+	// Cache and return
+	t.graphCache.Store(timestamp, g)
+	return g
+}
+
+// Chains returns all chains in the configuration.
+func (t *temporalDependencySet) Chains() []eth.ChainID {
+	return t.config.ChainIDs()
+}
+
+// HasChain returns true if the chain is in the configuration.
+func (t *temporalDependencySet) HasChain(chainID eth.ChainID) bool {
+	_, exists := t.chainSet[chainID]
+	return exists
+}
+
+// ActivationTimestamps returns all activation timestamps in ascending order.
+func (t *temporalDependencySet) ActivationTimestamps() []uint64 {
+	result := make([]uint64, len(t.sortedTimestamps))
+	copy(result, t.sortedTimestamps)
+	return result
+}

--- a/op-service/depset/transitive.go
+++ b/op-service/depset/transitive.go
@@ -1,0 +1,95 @@
+package depset
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// TransitiveClosure computes the transitive closure of all dependencies for a single chain.
+// Returns all chains that are reachable from the given chain (directly or transitively).
+// The result includes only the reachable chains, not the source chain itself.
+//
+// For example, if A → B → C, then TransitiveClosure(graph, A) returns [B, C].
+// If there's a cycle A → B → C → A, the result is still [B, C] (excluding the source).
+func TransitiveClosure(g *DependencyGraph, chainID eth.ChainID) []eth.ChainID {
+	if !g.HasChain(chainID) {
+		return nil
+	}
+
+	visited := make(map[eth.ChainID]struct{})
+	var result []eth.ChainID
+
+	// Mark the source as visited to exclude it from results
+	visited[chainID] = struct{}{}
+
+	// DFS to find all reachable chains
+	var dfs func(current eth.ChainID)
+	dfs = func(current eth.ChainID) {
+		deps := g.Dependencies(current)
+		for _, dep := range deps {
+			if _, seen := visited[dep]; !seen {
+				visited[dep] = struct{}{}
+				result = append(result, dep)
+				dfs(dep)
+			}
+		}
+	}
+
+	dfs(chainID)
+	eth.SortChainID(result)
+	return result
+}
+
+// ComputeAllTransitiveClosures computes the transitive closure for every chain in the graph.
+// Returns a map from chain ID to the list of all chains it transitively depends on.
+func ComputeAllTransitiveClosures(g *DependencyGraph) map[eth.ChainID][]eth.ChainID {
+	result := make(map[eth.ChainID][]eth.ChainID)
+	for _, chainID := range g.Chains() {
+		result[chainID] = TransitiveClosure(g, chainID)
+	}
+	return result
+}
+
+// chainIDSet is a helper for set operations on chain IDs.
+type chainIDSet map[eth.ChainID]struct{}
+
+func newChainIDSet(ids []eth.ChainID) chainIDSet {
+	s := make(chainIDSet)
+	for _, id := range ids {
+		s[id] = struct{}{}
+	}
+	return s
+}
+
+func (s chainIDSet) contains(id eth.ChainID) bool {
+	_, ok := s[id]
+	return ok
+}
+
+func (s chainIDSet) toSlice() []eth.ChainID {
+	result := make([]eth.ChainID, 0, len(s))
+	for id := range s {
+		result = append(result, id)
+	}
+	eth.SortChainID(result)
+	return result
+}
+
+// MissingTransitiveDependencies returns the transitive dependencies of a chain
+// that are not explicitly declared in its direct dependencies.
+//
+// For example, if A declares dependencies [B] but B depends on C,
+// and A doesn't declare C, then C is a missing transitive dependency.
+func MissingTransitiveDependencies(g *DependencyGraph, chainID eth.ChainID) []eth.ChainID {
+	declared := newChainIDSet(g.Dependencies(chainID))
+	transitive := newChainIDSet(TransitiveClosure(g, chainID))
+
+	var missing []eth.ChainID
+	for dep := range transitive {
+		if !declared.contains(dep) {
+			missing = append(missing, dep)
+		}
+	}
+
+	eth.SortChainID(missing)
+	return missing
+}

--- a/op-service/depset/types.go
+++ b/op-service/depset/types.go
@@ -1,0 +1,68 @@
+package depset
+
+import (
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// DependencyUpdate represents a timestamped dependency change (DSO fork).
+// At the given timestamp, the chain's dependency set becomes the specified list.
+type DependencyUpdate struct {
+	// Timestamp is the Unix timestamp when this dependency set becomes active.
+	Timestamp uint64 `json:"timestamp" toml:"timestamp"`
+
+	// Dependencies is the list of chain IDs that this chain depends on at this timestamp.
+	// All transitive dependencies must be explicitly listed.
+	Dependencies []eth.ChainID `json:"dependencies" toml:"dependencies"`
+}
+
+// ChainDependencyConfig holds all dependency updates for a single chain.
+type ChainDependencyConfig struct {
+	// ChainID is the identifier of this chain.
+	ChainID eth.ChainID `json:"chain_id" toml:"chain_id"`
+
+	// DependencyUpdates is a list of timestamped dependency changes.
+	// Must be sorted by timestamp in ascending order.
+	DependencyUpdates []DependencyUpdate `json:"dependency_updates" toml:"dependency_updates"`
+}
+
+// TemporalDependencyConfig is the full multi-chain dependency configuration.
+// This is the top-level configuration structure that describes dependency
+// relationships across all chains over time.
+type TemporalDependencyConfig struct {
+	// Chains is the list of chain configurations.
+	Chains []ChainDependencyConfig `json:"chains" toml:"chains"`
+}
+
+// ChainIDs returns the list of all chain IDs in the configuration.
+func (c *TemporalDependencyConfig) ChainIDs() []eth.ChainID {
+	ids := make([]eth.ChainID, len(c.Chains))
+	for i, chain := range c.Chains {
+		ids[i] = chain.ChainID
+	}
+	return ids
+}
+
+// AllTimestamps returns all unique activation timestamps across all chains, sorted ascending.
+func (c *TemporalDependencyConfig) AllTimestamps() []uint64 {
+	seen := make(map[uint64]struct{})
+	for _, chain := range c.Chains {
+		for _, update := range chain.DependencyUpdates {
+			seen[update.Timestamp] = struct{}{}
+		}
+	}
+
+	timestamps := make([]uint64, 0, len(seen))
+	for ts := range seen {
+		timestamps = append(timestamps, ts)
+	}
+
+	// Sort ascending
+	for i := 0; i < len(timestamps)-1; i++ {
+		for j := i + 1; j < len(timestamps); j++ {
+			if timestamps[i] > timestamps[j] {
+				timestamps[i], timestamps[j] = timestamps[j], timestamps[i]
+			}
+		}
+	}
+	return timestamps
+}

--- a/op-service/depset/types.go
+++ b/op-service/depset/types.go
@@ -33,6 +33,16 @@ type TemporalDependencyConfig struct {
 	Chains []ChainDependencyConfig `json:"chains" toml:"chains"`
 }
 
+// ChainDependencyConfigWithInteropTime pairs a chain's dependency config with its interop activation time.
+// This is used for validation to ensure the first dependency_updates timestamp matches interop_time.
+type ChainDependencyConfigWithInteropTime struct {
+	ChainDependencyConfig
+
+	// InteropTime is the timestamp when interop activates for this chain (from hardforks section).
+	// The first DependencyUpdate timestamp must match this value.
+	InteropTime uint64 `json:"interop_time" toml:"interop_time"`
+}
+
 // ChainIDs returns the list of all chain IDs in the configuration.
 func (c *TemporalDependencyConfig) ChainIDs() []eth.ChainID {
 	ids := make([]eth.ChainID, len(c.Chains))

--- a/op-service/depset/validate.go
+++ b/op-service/depset/validate.go
@@ -182,3 +182,47 @@ func ValidateGraph(g *DependencyGraph) error {
 
 	return nil
 }
+
+// ValidateInteropTimeMatch validates that a chain's first dependency_updates timestamp
+// matches its interop_time from the hardforks section.
+// This ensures the dependency set activates exactly when interop activates.
+func ValidateInteropTimeMatch(cfg *ChainDependencyConfigWithInteropTime) error {
+	if len(cfg.DependencyUpdates) == 0 {
+		return &ValidationError{
+			ChainID: &cfg.ChainID,
+			Message: "chain has interop_time but no dependency_updates",
+		}
+	}
+
+	firstUpdate := cfg.DependencyUpdates[0]
+	if firstUpdate.Timestamp != cfg.InteropTime {
+		return &ValidationError{
+			ChainID:   &cfg.ChainID,
+			Timestamp: firstUpdate.Timestamp,
+			Message: fmt.Sprintf(
+				"first dependency_updates timestamp (%d) must match interop_time (%d)",
+				firstUpdate.Timestamp, cfg.InteropTime,
+			),
+		}
+	}
+
+	return nil
+}
+
+// ValidateAllInteropTimes validates that all chains' first dependency_updates timestamps
+// match their respective interop_times.
+func ValidateAllInteropTimes(configs []ChainDependencyConfigWithInteropTime) error {
+	var errs []error
+
+	for _, cfg := range configs {
+		if err := ValidateInteropTimeMatch(&cfg); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}

--- a/op-service/depset/validate.go
+++ b/op-service/depset/validate.go
@@ -1,0 +1,184 @@
+package depset
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// ValidationError represents a validation failure with context.
+type ValidationError struct {
+	// Timestamp at which the validation failed (0 if not timestamp-specific)
+	Timestamp uint64
+
+	// ChainID that has the validation issue (nil if not chain-specific)
+	ChainID *eth.ChainID
+
+	// Missing contains the chain IDs that are missing from the declared dependencies
+	Missing []eth.ChainID
+
+	// Message describes the validation failure
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	var sb strings.Builder
+	sb.WriteString(e.Message)
+
+	if e.Timestamp > 0 {
+		sb.WriteString(fmt.Sprintf(" (at timestamp %d)", e.Timestamp))
+	}
+
+	if e.ChainID != nil {
+		sb.WriteString(fmt.Sprintf(" for chain %s", e.ChainID.String()))
+	}
+
+	if len(e.Missing) > 0 {
+		sb.WriteString(": missing [")
+		for i, m := range e.Missing {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(m.String())
+		}
+		sb.WriteString("]")
+	}
+
+	return sb.String()
+}
+
+// Validate checks a TemporalDependencyConfig for validity.
+// It ensures that at every activation timestamp, all transitive dependencies
+// are explicitly declared for every chain.
+//
+// Returns nil if the configuration is valid, or an error describing the issues.
+func Validate(cfg *TemporalDependencyConfig) error {
+	if cfg == nil {
+		return errors.New("nil configuration")
+	}
+
+	if len(cfg.Chains) == 0 {
+		return nil // Empty config is valid
+	}
+
+	// Validate structure first
+	if err := validateStructure(cfg); err != nil {
+		return err
+	}
+
+	// Validate at each activation timestamp
+	timestamps := cfg.AllTimestamps()
+	var errs []error
+
+	for _, ts := range timestamps {
+		if err := ValidateAtTimestamp(cfg, ts); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
+// validateStructure checks the structural validity of the configuration.
+func validateStructure(cfg *TemporalDependencyConfig) error {
+	var errs []error
+
+	seenChains := make(map[eth.ChainID]struct{})
+	for _, chainCfg := range cfg.Chains {
+		// Check for duplicate chain definitions
+		if _, seen := seenChains[chainCfg.ChainID]; seen {
+			errs = append(errs, &ValidationError{
+				ChainID: &chainCfg.ChainID,
+				Message: "duplicate chain definition",
+			})
+		}
+		seenChains[chainCfg.ChainID] = struct{}{}
+
+		// Check timestamps are in ascending order
+		var prevTs uint64
+		for i, update := range chainCfg.DependencyUpdates {
+			if i > 0 && update.Timestamp <= prevTs {
+				errs = append(errs, &ValidationError{
+					ChainID:   &chainCfg.ChainID,
+					Timestamp: update.Timestamp,
+					Message:   "dependency updates must have strictly increasing timestamps",
+				})
+			}
+			prevTs = update.Timestamp
+
+			// Check for self-dependency
+			for _, dep := range update.Dependencies {
+				if dep.Cmp(chainCfg.ChainID) == 0 {
+					errs = append(errs, &ValidationError{
+						ChainID:   &chainCfg.ChainID,
+						Timestamp: update.Timestamp,
+						Message:   "chain cannot depend on itself",
+					})
+				}
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
+// ValidateAtTimestamp validates the dependency graph at a specific timestamp.
+// It checks that all transitive dependencies are explicitly declared.
+func ValidateAtTimestamp(cfg *TemporalDependencyConfig, ts uint64) error {
+	graph := BuildGraphAt(cfg, ts)
+	var errs []error
+
+	for _, chainID := range graph.Chains() {
+		missing := MissingTransitiveDependencies(graph, chainID)
+		if len(missing) > 0 {
+			chainCopy := chainID
+			errs = append(errs, &ValidationError{
+				Timestamp: ts,
+				ChainID:   &chainCopy,
+				Missing:   missing,
+				Message:   "missing transitive dependencies",
+			})
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
+// ValidateGraph validates a single DependencyGraph for explicit transitivity.
+// This is useful when you already have a graph and don't need temporal validation.
+func ValidateGraph(g *DependencyGraph) error {
+	var errs []error
+
+	for _, chainID := range g.Chains() {
+		missing := MissingTransitiveDependencies(g, chainID)
+		if len(missing) > 0 {
+			chainCopy := chainID
+			errs = append(errs, &ValidationError{
+				Timestamp: g.Timestamp(),
+				ChainID:   &chainCopy,
+				Missing:   missing,
+				Message:   "missing transitive dependencies",
+			})
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds new `op-service/depset/` package for managing and validating interop dependency sets
- Supports temporal dependency configuration with timestamped updates (DSO forks, inspired by Ethereum's BPO forks from EIP-7892)
- Validates that all transitive dependencies are explicitly declared
- Computes interop sets (strongly connected components) from dependency graphs

## Key Features

| Component | Description |
|-----------|-------------|
| `TemporalDependencyConfig` | Multi-chain config with timestamped dependency updates |
| `DependencyGraph` | Graph representation with adjacency list |
| `Validate()` | Ensures all transitive deps are explicit at every timestamp |
| `ComputeSCCs()` | Tarjan's algorithm for strongly connected components |
| `InteropSetAt()` | Find interop set containing a chain at a timestamp |

## Core API

```go
// Create from config (validates first)
tds, err := NewValidatedTemporalDependencySet(cfg)

// Query dependencies at a timestamp
deps := tds.DependenciesAt(chainID, timestamp)

// Get interop set (SCC) at a timestamp  
interopSet := tds.InteropSetAt(chainID, timestamp)

// Get full graph snapshot
graph := tds.GraphAt(timestamp)
```

## Test plan

- [x] Unit tests for all components (21 tests passing)
- [x] Tests for transitive closure computation
- [x] Tests for validation (valid configs, missing deps, self-deps, duplicates)
- [x] Tests for SCC computation and interop set derivation
- [x] Tests for temporal queries at different timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)