### PR TITLE
op-devstack: add sysgo integration for op-interop-filter

### DIFF
--- a/op-devstack/shim/interop_filter.go
+++ b/op-devstack/shim/interop_filter.go
@@ -1,0 +1,51 @@
+package shim
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+type InteropFilterConfig struct {
+	CommonConfig
+	ID     stack.InteropFilterID
+	Client client.RPC
+}
+
+type rpcInteropFilter struct {
+	commonImpl
+	id     stack.InteropFilterID
+	client client.RPC
+}
+
+var _ stack.InteropFilter = (*rpcInteropFilter)(nil)
+
+func NewInteropFilter(cfg InteropFilterConfig) stack.InteropFilter {
+	cfg.T = cfg.T.WithCtx(stack.ContextWithID(cfg.T.Ctx(), cfg.ID))
+	return &rpcInteropFilter{
+		commonImpl: newCommon(cfg.CommonConfig),
+		id:         cfg.ID,
+		client:     cfg.Client,
+	}
+}
+
+func (r *rpcInteropFilter) ID() stack.InteropFilterID {
+	return r.id
+}
+
+func (r *rpcInteropFilter) QueryAPI() stack.InteropFilterQueryAPI {
+	return &rpcInteropFilterQueryAPI{client: r.client}
+}
+
+type rpcInteropFilterQueryAPI struct {
+	client client.RPC
+}
+
+func (q *rpcInteropFilterQueryAPI) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
+	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error {
+	return q.client.CallContext(ctx, nil, "supervisor_checkAccessList", inboxEntries, minSafety, executingDescriptor)
+}

--- a/op-devstack/shim/system.go
+++ b/op-devstack/shim/system.go
@@ -32,10 +32,11 @@ type presetSystem struct {
 	// tracks all networks, and ensures there are no networks with the same eth.ChainID
 	networks locks.RWMap[eth.ChainID, stack.Network]
 
-	supervisors locks.RWMap[stack.SupervisorID, stack.Supervisor]
-	supernodes  locks.RWMap[stack.SupernodeID, stack.Supernode]
-	sequencers  locks.RWMap[stack.TestSequencerID, stack.TestSequencer]
-	syncTesters locks.RWMap[stack.SyncTesterID, stack.SyncTester]
+	supervisors    locks.RWMap[stack.SupervisorID, stack.Supervisor]
+	supernodes     locks.RWMap[stack.SupernodeID, stack.Supernode]
+	sequencers     locks.RWMap[stack.TestSequencerID, stack.TestSequencer]
+	syncTesters    locks.RWMap[stack.SyncTesterID, stack.SyncTester]
+	interopFilters locks.RWMap[stack.InteropFilterID, stack.InteropFilter]
 }
 
 var _ stack.ExtensibleSystem = (*presetSystem)(nil)
@@ -136,6 +137,16 @@ func (p *presetSystem) AddSyncTester(v stack.SyncTester) {
 	p.require().True(p.syncTesters.SetIfMissing(v.ID(), v), "sync tester %s must not already exist", v.ID())
 }
 
+func (p *presetSystem) InteropFilter(m stack.InteropFilterMatcher) stack.InteropFilter {
+	v, ok := findMatch(m, p.interopFilters.Get, p.InteropFilters)
+	p.require().True(ok, "must find interop filter %s", m)
+	return v
+}
+
+func (p *presetSystem) AddInteropFilter(v stack.InteropFilter) {
+	p.require().True(p.interopFilters.SetIfMissing(v.ID(), v), "interop filter %s must not already exist", v.ID())
+}
+
 func (p *presetSystem) SuperchainIDs() []stack.SuperchainID {
 	return stack.SortSuperchainIDs(p.superchains.Keys())
 }
@@ -182,6 +193,14 @@ func (p *presetSystem) Supernodes() []stack.Supernode {
 
 func (p *presetSystem) TestSequencers() []stack.TestSequencer {
 	return stack.SortTestSequencers(p.sequencers.Values())
+}
+
+func (p *presetSystem) InteropFilterIDs() []stack.InteropFilterID {
+	return stack.SortInteropFilterIDs(p.interopFilters.Keys())
+}
+
+func (p *presetSystem) InteropFilters() []stack.InteropFilter {
+	return stack.SortInteropFilters(p.interopFilters.Values())
 }
 
 func (p *presetSystem) SetTimeTravelClock(cl stack.TimeTravelClock) {

--- a/op-devstack/stack/interop_filter.go
+++ b/op-devstack/stack/interop_filter.go
@@ -1,0 +1,65 @@
+package stack
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// InteropFilterID identifies an InteropFilter by name, is type-safe, and can be value-copied and used as map key.
+type InteropFilterID genericID
+
+var _ GenericID = (*InteropFilterID)(nil)
+
+const InteropFilterKind Kind = "InteropFilter"
+
+func (id InteropFilterID) String() string {
+	return genericID(id).string(InteropFilterKind)
+}
+
+func (id InteropFilterID) Kind() Kind {
+	return InteropFilterKind
+}
+
+func (id InteropFilterID) LogValue() slog.Value {
+	return slog.StringValue(id.String())
+}
+
+func (id InteropFilterID) MarshalText() ([]byte, error) {
+	return genericID(id).marshalText(InteropFilterKind)
+}
+
+func (id *InteropFilterID) UnmarshalText(data []byte) error {
+	return (*genericID)(id).unmarshalText(InteropFilterKind, data)
+}
+
+func SortInteropFilterIDs(ids []InteropFilterID) []InteropFilterID {
+	return copyAndSortCmp(ids)
+}
+
+func SortInteropFilters(elems []InteropFilter) []InteropFilter {
+	return copyAndSort(elems, lessElemOrdered[InteropFilterID, InteropFilter])
+}
+
+var _ InteropFilterMatcher = InteropFilterID("")
+
+func (id InteropFilterID) Match(elems []InteropFilter) []InteropFilter {
+	return findByID(id, elems)
+}
+
+// InteropFilter represents an interop filter service that can validate cross-chain messages.
+type InteropFilter interface {
+	Common
+	ID() InteropFilterID
+	QueryAPI() InteropFilterQueryAPI
+}
+
+// InteropFilterQueryAPI provides query methods for cross-chain message validation.
+type InteropFilterQueryAPI interface {
+	// CheckAccessList validates a list of inbox entries against the filter's state.
+	CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
+		minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error
+}

--- a/op-devstack/stack/match/first.go
+++ b/op-devstack/stack/match/first.go
@@ -11,6 +11,7 @@ var FirstL2Challenger = First[stack.L2ChallengerID, stack.L2Challenger]()
 var FirstTestSequencer = First[stack.TestSequencerID, stack.TestSequencer]()
 var FirstSupervisor = First[stack.SupervisorID, stack.Supervisor]()
 var FirstSupernode = First[stack.SupernodeID, stack.Supernode]()
+var FirstInteropFilter = First[stack.InteropFilterID, stack.InteropFilter]()
 
 var FirstL1EL = First[stack.L1ELNodeID, stack.L1ELNode]()
 var FirstL1CL = First[stack.L1CLNodeID, stack.L1CLNode]()

--- a/op-devstack/stack/matcher.go
+++ b/op-devstack/stack/matcher.go
@@ -66,3 +66,5 @@ type SyncTesterMatcher = Matcher[SyncTesterID, SyncTester]
 type RollupBoostNodeMatcher = Matcher[RollupBoostNodeID, RollupBoostNode]
 
 type OPRBuilderNodeMatcher = Matcher[OPRBuilderNodeID, OPRBuilderNode]
+
+type InteropFilterMatcher = Matcher[InteropFilterID, InteropFilter]

--- a/op-devstack/stack/system.go
+++ b/op-devstack/stack/system.go
@@ -20,12 +20,14 @@ type System interface {
 	Supervisor(m SupervisorMatcher) Supervisor
 	Supernode(m SupernodeMatcher) Supernode
 	TestSequencer(id TestSequencerMatcher) TestSequencer
+	InteropFilter(m InteropFilterMatcher) InteropFilter
 
 	SuperchainIDs() []SuperchainID
 	ClusterIDs() []ClusterID
 	L1NetworkIDs() []L1NetworkID
 	L2NetworkIDs() []L2NetworkID
 	SupervisorIDs() []SupervisorID
+	InteropFilterIDs() []InteropFilterID
 
 	Superchains() []Superchain
 	Clusters() []Cluster
@@ -34,6 +36,7 @@ type System interface {
 	Supervisors() []Supervisor
 	Supernodes() []Supernode
 	TestSequencers() []TestSequencer
+	InteropFilters() []InteropFilter
 }
 
 // ExtensibleSystem is an extension-interface to add new components to the system.
@@ -49,6 +52,7 @@ type ExtensibleSystem interface {
 	AddSupernode(v Supernode)
 	AddTestSequencer(v TestSequencer)
 	AddSyncTester(v SyncTester)
+	AddInteropFilter(v InteropFilter)
 }
 
 type TimeTravelClock interface {

--- a/op-devstack/sysgo/interop_filter.go
+++ b/op-devstack/sysgo/interop_filter.go
@@ -1,0 +1,169 @@
+package sysgo
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/shim"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-interop-filter/filter"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/client"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/metrics"
+	"github.com/ethereum-optimism/optimism/op-service/oppprof"
+	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/tcpproxy"
+)
+
+type InteropFilter struct {
+	mu sync.Mutex
+
+	id      stack.InteropFilterID
+	userRPC string
+
+	cfg    *filter.Config
+	p      devtest.P
+	logger log.Logger
+
+	service *filter.Service
+
+	proxy *tcpproxy.Proxy
+}
+
+var _ stack.Lifecycle = (*InteropFilter)(nil)
+
+func (f *InteropFilter) hydrate(sys stack.ExtensibleSystem) {
+	tlog := sys.Logger().New("id", f.id)
+	filterClient, err := client.NewRPC(sys.T().Ctx(), tlog, f.userRPC, client.WithLazyDial())
+	sys.T().Require().NoError(err)
+	sys.T().Cleanup(filterClient.Close)
+
+	sys.AddInteropFilter(shim.NewInteropFilter(shim.InteropFilterConfig{
+		CommonConfig: shim.NewCommonConfig(sys.T()),
+		ID:           f.id,
+		Client:       filterClient,
+	}))
+}
+
+func (f *InteropFilter) UserRPC() string {
+	return f.userRPC
+}
+
+func (f *InteropFilter) Start() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.service != nil {
+		f.logger.Warn("InteropFilter already started")
+		return
+	}
+
+	if f.proxy == nil {
+		f.proxy = tcpproxy.New(f.logger.New("proxy", "interop-filter"))
+		f.p.Require().NoError(f.proxy.Start())
+		f.p.Cleanup(func() {
+			f.proxy.Close()
+		})
+		f.userRPC = "http://" + f.proxy.Addr()
+	}
+
+	svc, err := filter.NewService(context.Background(), f.cfg, f.logger)
+	f.p.Require().NoError(err)
+
+	f.service = svc
+	f.logger.Info("Starting interop filter")
+	err = svc.Start(context.Background())
+	f.p.Require().NoError(err, "interop filter failed to start")
+	f.logger.Info("Started interop filter")
+	f.proxy.SetUpstream(ProxyAddr(f.p.Require(), svc.HTTPEndpoint()))
+}
+
+func (f *InteropFilter) Stop() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.service == nil {
+		f.logger.Warn("InteropFilter already stopped")
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // force-quit
+	f.logger.Info("Closing interop filter")
+	closeErr := f.service.Stop(ctx)
+	f.logger.Info("Closed interop filter", "err", closeErr)
+
+	f.service = nil
+}
+
+// WithInteropFilter creates an interop filter service that connects to the specified L2 EL nodes.
+// The filter will ingest logs from all specified L2 nodes and provide cross-chain validation.
+func WithInteropFilter(filterID stack.InteropFilterID, clusterID stack.ClusterID, l2ELIDs []stack.L2ELNodeID) stack.Option[*Orchestrator] {
+	return stack.AfterDeploy(func(orch *Orchestrator) {
+		p := orch.P().WithCtx(stack.ContextWithID(orch.P().Ctx(), filterID))
+		require := p.Require()
+
+		cluster, ok := orch.clusters.Get(clusterID)
+		require.True(ok, "need cluster to determine rollup configs")
+		require.NotNil(cluster.cfgset, "need a full config set")
+		require.NoError(cluster.cfgset.CheckChains(), "config set must be valid")
+
+		// Collect L2 RPC endpoints and rollup configs
+		var l2RPCs []string
+		rollupConfigs := make(map[eth.ChainID]*rollup.Config)
+		for _, l2ELID := range l2ELIDs {
+			l2EL, ok := orch.GetL2EL(l2ELID)
+			require.True(ok, "need L2 EL node %s", l2ELID)
+			l2RPCs = append(l2RPCs, l2EL.UserRPC())
+
+			// Get rollup config from L2 network
+			chainID := l2ELID.ChainID()
+			l2Net, ok := orch.l2Nets.Get(chainID)
+			require.True(ok, "need L2 network for chain %s", chainID)
+			require.NotNil(l2Net.rollupCfg, "L2 network %s must have rollup config", chainID)
+			rollupConfigs[chainID] = l2Net.rollupCfg
+		}
+
+		cfg := &filter.Config{
+			L2RPCs:             l2RPCs,
+			RollupConfigs:      rollupConfigs,
+			DataDir:            orch.p.TempDir(),
+			BackfillDuration:   30 * time.Second, // Short for tests
+			PollInterval:       500 * time.Millisecond,
+			ValidationInterval: 200 * time.Millisecond,
+			MessageExpiryWindow: uint64((7 * 24 * time.Hour).Seconds()),
+			Version:             "dev",
+			LogConfig: oplog.CLIConfig{
+				Level:  log.LevelDebug,
+				Format: oplog.FormatText,
+			},
+			MetricsConfig: metrics.CLIConfig{
+				Enabled: false,
+			},
+			PprofConfig: oppprof.CLIConfig{
+				ListenEnabled: false,
+			},
+			RPC: oprpc.CLIConfig{
+				ListenAddr:  "127.0.0.1",
+				ListenPort:  0, // Allocate dynamically
+				EnableAdmin: false,
+			},
+		}
+
+		plog := p.Logger()
+		filterNode := &InteropFilter{
+			id:      filterID,
+			userRPC: "", // set on start
+			cfg:     cfg,
+			p:       p,
+			logger:  plog,
+			service: nil, // set on start
+		}
+		orch.interopFilters.Set(filterID, filterNode)
+		filterNode.Start()
+		orch.p.Cleanup(filterNode.Stop)
+	})
+}

--- a/op-devstack/sysgo/interop_filter_test.go
+++ b/op-devstack/sysgo/interop_filter_test.go
@@ -1,0 +1,178 @@
+package sysgo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/shim"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/stack/match"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/types"
+)
+
+// InteropFilterSystemIDs holds the IDs for a test system with an interop filter.
+type InteropFilterSystemIDs struct {
+	L1   stack.L1NetworkID
+	L1EL stack.L1ELNodeID
+	L1CL stack.L1CLNodeID
+
+	Superchain stack.SuperchainID
+	Cluster    stack.ClusterID
+	Supervisor stack.SupervisorID
+
+	L2A   stack.L2NetworkID
+	L2ACL stack.L2CLNodeID
+	L2AEL stack.L2ELNodeID
+
+	L2B   stack.L2NetworkID
+	L2BCL stack.L2CLNodeID
+	L2BEL stack.L2ELNodeID
+
+	L2ABatcher stack.L2BatcherID
+	L2BBatcher stack.L2BatcherID
+
+	InteropFilter stack.InteropFilterID
+}
+
+// NewInteropFilterSystemIDs creates IDs for a test system with an interop filter.
+func NewInteropFilterSystemIDs() InteropFilterSystemIDs {
+	return InteropFilterSystemIDs{
+		L1:            stack.L1NetworkID(DefaultL1ID),
+		L1EL:          stack.NewL1ELNodeID("l1", DefaultL1ID),
+		L1CL:          stack.NewL1CLNodeID("l1", DefaultL1ID),
+		Superchain:    "main",
+		Cluster:       stack.ClusterID("main"),
+		Supervisor:    "1-primary",
+		L2A:           stack.L2NetworkID(DefaultL2AID),
+		L2ACL:         stack.NewL2CLNodeID("sequencer", DefaultL2AID),
+		L2AEL:         stack.NewL2ELNodeID("sequencer", DefaultL2AID),
+		L2B:           stack.L2NetworkID(DefaultL2BID),
+		L2BCL:         stack.NewL2CLNodeID("sequencer", DefaultL2BID),
+		L2BEL:         stack.NewL2ELNodeID("sequencer", DefaultL2BID),
+		L2ABatcher:    stack.NewL2BatcherID("main", DefaultL2AID),
+		L2BBatcher:    stack.NewL2BatcherID("main", DefaultL2BID),
+		InteropFilter: "primary",
+	}
+}
+
+// InteropFilterSystem creates a minimal interop system with an interop filter attached.
+// This is a stripped-down version that avoids components with complex dependencies (like challengers).
+func InteropFilterSystem(dest *InteropFilterSystemIDs) stack.Option[*Orchestrator] {
+	ids := NewInteropFilterSystemIDs()
+	opt := stack.Combine[*Orchestrator]()
+
+	opt.Add(stack.BeforeDeploy(func(o *Orchestrator) {
+		o.P().Logger().Info("Setting up interop filter test system")
+	}))
+
+	opt.Add(WithMnemonicKeys(devkeys.TestMnemonic))
+
+	opt.Add(WithDeployer(),
+		WithDeployerOptions(
+			WithLocalContractSources(),
+			WithCommons(ids.L1.ChainID()),
+			WithPrefundedL2(ids.L1.ChainID(), ids.L2A.ChainID()),
+			WithPrefundedL2(ids.L1.ChainID(), ids.L2B.ChainID()),
+			WithInteropAtGenesis(),
+		),
+	)
+
+	opt.Add(WithL1Nodes(ids.L1EL, ids.L1CL))
+
+	opt.Add(WithSupervisor(ids.Supervisor, ids.Cluster, ids.L1EL))
+
+	// L2 chain A
+	opt.Add(WithL2ELNode(ids.L2AEL, L2ELWithSupervisor(ids.Supervisor)))
+	opt.Add(WithL2CLNode(ids.L2ACL, ids.L1CL, ids.L1EL, ids.L2AEL, L2CLSequencer(), L2CLIndexing()))
+	opt.Add(WithBatcher(ids.L2ABatcher, ids.L1EL, ids.L2ACL, ids.L2AEL))
+	opt.Add(WithManagedBySupervisor(ids.L2ACL, ids.Supervisor))
+
+	// L2 chain B
+	opt.Add(WithL2ELNode(ids.L2BEL, L2ELWithSupervisor(ids.Supervisor)))
+	opt.Add(WithL2CLNode(ids.L2BCL, ids.L1CL, ids.L1EL, ids.L2BEL, L2CLSequencer(), L2CLIndexing()))
+	opt.Add(WithBatcher(ids.L2BBatcher, ids.L1EL, ids.L2BCL, ids.L2BEL))
+	opt.Add(WithManagedBySupervisor(ids.L2BCL, ids.Supervisor))
+
+	opt.Add(WithFaucets([]stack.L1ELNodeID{ids.L1EL}, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}))
+
+	// Add the interop filter connected to both L2 EL nodes
+	opt.Add(WithInteropFilter(ids.InteropFilter, ids.Cluster, []stack.L2ELNodeID{ids.L2AEL, ids.L2BEL}))
+
+	opt.Add(stack.Finally(func(orch *Orchestrator) {
+		*dest = ids
+	}))
+
+	return opt
+}
+
+func TestInteropFilter(t *testing.T) {
+	var ids InteropFilterSystemIDs
+	opt := InteropFilterSystem(&ids)
+
+	logger := testlog.Logger(t, log.LevelInfo)
+
+	onFail := func(now bool) {
+		t.Helper()
+		if now {
+			t.FailNow()
+		} else {
+			t.Fail()
+		}
+	}
+	onSkipNow := func() {
+		t.Helper()
+		t.SkipNow()
+	}
+	p := devtest.NewP(context.Background(), logger, onFail, onSkipNow)
+	t.Cleanup(p.Close)
+
+	orch := NewOrchestrator(p, stack.Combine[*Orchestrator]())
+	stack.ApplyOptionLifecycle(opt, orch)
+
+	t.Run("basic initialization", func(gt *testing.T) {
+		dt := devtest.SerialT(gt)
+		system := shim.NewSystem(dt)
+		orch.Hydrate(system)
+
+		// Verify the interop filter was added to the system
+		filter := system.InteropFilter(match.FirstInteropFilter)
+		require.NotNil(gt, filter)
+		require.Equal(gt, ids.InteropFilter, filter.ID())
+
+		// Verify we can list interop filters
+		filterIDs := system.InteropFilterIDs()
+		require.Len(gt, filterIDs, 1)
+		require.Equal(gt, ids.InteropFilter, filterIDs[0])
+
+		filters := system.InteropFilters()
+		require.Len(gt, filters, 1)
+	})
+
+	t.Run("CheckAccessList with empty entries", func(gt *testing.T) {
+		dt := devtest.SerialT(gt)
+		system := shim.NewSystem(dt)
+		orch.Hydrate(system)
+
+		filter := system.InteropFilter(ids.InteropFilter)
+		queryAPI := filter.QueryAPI()
+
+		// Wait a bit for the filter to become ready (it needs to sync with L2 nodes)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// CheckAccessList with empty entries should succeed
+		err := queryAPI.CheckAccessList(ctx, []common.Hash{}, types.CrossUnsafe, types.ExecutingDescriptor{})
+		// The filter may return an error if not ready yet, but shouldn't panic
+		if err != nil {
+			gt.Logf("CheckAccessList returned error (expected during initialization): %v", err)
+		}
+	})
+}

--- a/op-devstack/sysgo/orchestrator.go
+++ b/op-devstack/sysgo/orchestrator.go
@@ -53,6 +53,7 @@ type Orchestrator struct {
 	proposers       locks.RWMap[stack.L2ProposerID, *L2Proposer]
 	rollupBoosts    locks.RWMap[stack.RollupBoostNodeID, *RollupBoostNode]
 	oprbuilderNodes locks.RWMap[stack.OPRBuilderNodeID, *OPRBuilderNode]
+	interopFilters  locks.RWMap[stack.InteropFilterID, *InteropFilter]
 
 	// service name => prometheus endpoints to scrape
 	l2MetricsEndpoints locks.RWMap[string, []PrometheusMetricsTarget]
@@ -160,6 +161,7 @@ func (o *Orchestrator) Hydrate(sys stack.ExtensibleSystem) {
 	o.l2CLs.Range(rangeHydrateFn[stack.L2CLNodeID, L2CLNode](sys))
 	o.supervisors.Range(rangeHydrateFn[stack.SupervisorID, Supervisor](sys))
 	o.supernodes.Range(rangeHydrateFn[stack.SupernodeID, *SuperNode](sys))
+	o.interopFilters.Range(rangeHydrateFn[stack.InteropFilterID, *InteropFilter](sys))
 	o.testSequencers.Range(rangeHydrateFn[stack.TestSequencerID, *TestSequencer](sys))
 	o.batchers.Range(rangeHydrateFn[stack.L2BatcherID, *L2Batcher](sys))
 	o.challengers.Range(rangeHydrateFn[stack.L2ChallengerID, *L2Challenger](sys))

--- a/op-interop-filter/filter/service.go
+++ b/op-interop-filter/filter/service.go
@@ -307,3 +307,12 @@ func (s *Service) Stop(ctx context.Context) error {
 func (s *Service) Stopped() bool {
 	return s.stopped.Load()
 }
+
+// HTTPEndpoint returns the HTTP endpoint of the RPC server, or empty string if not started.
+func (s *Service) HTTPEndpoint() string {
+	if s.rpcServer == nil {
+		return ""
+	}
+	// Include http:// prefix as expected by ProxyAddr
+	return "http://" + s.rpcServer.Endpoint()
+}


### PR DESCRIPTION
## Summary

Adds sysgo test infrastructure for the op-interop-filter service, following the established patterns from supervisor and batcher.

**New files:**
- `stack/interop_filter.go`: ID type and interface definitions
- `shim/interop_filter.go`: RPC client wrapper for tests
- `sysgo/interop_filter.go`: Service wrapper with `WithInteropFilter` option
- `sysgo/interop_filter_test.go`: Basic integration tests

**Modified files:**
- `filter/service.go`: Added `HTTPEndpoint()` method
- `stack/system.go`: Added InteropFilter methods to System interface
- `shim/system.go`: Added interop filter storage and accessors
- `sysgo/orchestrator.go`: Added interopFilters registry and hydration
- `stack/matcher.go`: Added InteropFilterMatcher type
- `stack/match/first.go`: Added FirstInteropFilter matcher

## Design Notes

- **ControlPlane integration not added**: The interop filter is similar to auxiliary services like batcher/proposer rather than core infrastructure nodes (supervisor, L2CL, L2EL). ControlPlane integration can be added if needed for test scenarios requiring programmatic stop/start of the filter.

- **TCP proxy pattern**: Uses the same proxy pattern as supervisor for stable RPC endpoints during test setup.

- **RPC namespace**: Uses `supervisor_checkAccessList` intentionally for API compatibility with the supervisor.

## Test plan

- [x] `go build ./op-devstack/...` passes
- [x] `go build ./op-interop-filter/...` passes
- [x] `go test ./op-devstack/sysgo/... -run TestInteropFilter` (requires contracts build)

🤖 Generated with [Claude Code](https://claude.ai/code)