### PR TITLE
Raise MAX_GAS_LIMIT from 500M to 2B gas

### DIFF
--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -101,7 +101,7 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     /// @notice The maximum gas limit that can be set for L2 blocks. This limit is used to enforce that the blocks
     ///         on L2 are not too large to process and prove. Over time, this value can be increased as various
     ///         optimizations and improvements are made to the system at large.
-    uint64 internal constant MAX_GAS_LIMIT = 500_000_000;
+    uint64 internal constant MAX_GAS_LIMIT = 2_000_000_000;
 
     /// @notice Fixed L2 gas overhead. Used as part of the L2 fee calculation.
     ///         Deprecated since the Ecotone network upgrade


### PR DESCRIPTION
## Summary
- Raises `MAX_GAS_LIMIT` in `SystemConfig.sol` from 500M to 2B (2 gigagas)
- 1-line change to the hardcoded constant

## Context
The current 500M cap is unnecessarily restrictive. This raises it to 2B to allow higher-throughput L2 block gas limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)