### PR TITLE
op-interop-filter: fix same-height reorg detection window

### DIFF
--- a/op-interop-filter/filter/lockstep_cross_validator.go
+++ b/op-interop-filter/filter/lockstep_cross_validator.go
@@ -291,6 +291,12 @@ func (v *LockstepCrossValidator) advanceValidation() {
 
 	// Lazy initialization: start from the configured start timestamp
 	if currentTs == 0 {
+		if err := v.validateTimestamp(v.startTimestamp); err != nil {
+			v.log.Error("Cross-validation failed during initialization", "timestamp", v.startTimestamp, "err", err)
+			v.setError(err.Error())
+			return
+		}
+
 		v.crossValidatedTs.Store(v.startTimestamp)
 		v.log.Info("Cross-validator initialized", "startTimestamp", v.startTimestamp)
 		return

--- a/op-interop-filter/filter/lockstep_cross_validator_test.go
+++ b/op-interop-filter/filter/lockstep_cross_validator_test.go
@@ -151,18 +151,7 @@ func TestCrossValidator_ValidationFailureSetsError(t *testing.T) {
 	mockA.AddLog(100, 10, 0, checksumA, types.BlockSeal{})
 	mockA.SetLatestTimestamp(101)
 
-	// Add INVALID executing message on chain B that references a non-existent log
-	mockB.AddExecMsg(IncludedMessage{
-		ExecutingMessage: &types.ExecutingMessage{
-			ChainID:   eth.ChainIDFromUInt64(testChainA), // References chain A
-			BlockNum:  999,                               // Non-existent block
-			LogIdx:    0,
-			Timestamp: 50,                          // Init timestamp
-			Checksum:  types.MessageChecksum{0xFF}, // Non-existent checksum
-		},
-		InclusionBlockNum:  11,
-		InclusionTimestamp: 101,
-	})
+	// No executing messages at start timestamp.
 	mockB.SetLatestTimestamp(101)
 
 	chains := map[eth.ChainID]ChainIngester{
@@ -184,7 +173,7 @@ func TestCrossValidator_ValidationFailureSetsError(t *testing.T) {
 	require.Nil(t, mockA.Error())
 	require.Nil(t, mockB.Error())
 
-	// First call triggers initialization (sets crossValidatedTs to minIngestedTs=101)
+	// First call validates and initializes start timestamp.
 	cv.advanceValidation()
 
 	// Simulate chains ingesting one more block (timestamp 102)
@@ -340,6 +329,38 @@ func TestAdvanceValidation_InitializesToStartTimestamp(t *testing.T) {
 	ts, ok := cv.CrossValidatedTimestamp()
 	require.True(t, ok)
 	require.Equal(t, uint64(100), ts, "should initialize to startTimestamp")
+}
+
+func TestAdvanceValidation_InitializationValidatesStartTimestamp(t *testing.T) {
+	mock := newMockChainIngester()
+	mock.SetReady(true)
+	mock.SetLatestTimestamp(100)
+
+	// Invalid executing message at the start timestamp.
+	mock.AddExecMsg(IncludedMessage{
+		ExecutingMessage: &types.ExecutingMessage{
+			ChainID:   eth.ChainIDFromUInt64(testChainA),
+			BlockNum:  999,
+			LogIdx:    0,
+			Timestamp: 50,
+			Checksum:  types.MessageChecksum{0xFF},
+		},
+		InclusionBlockNum:  11,
+		InclusionTimestamp: 100,
+	})
+
+	chains := map[eth.ChainID]ChainIngester{
+		eth.ChainIDFromUInt64(testChainA): mock,
+	}
+	cv := newTestCrossValidator(chains, testExpiryWindow, 100)
+
+	cv.advanceValidation()
+
+	require.NotNil(t, cv.Error())
+	require.Contains(t, cv.Error().Message, "validation failed")
+
+	_, ok := cv.CrossValidatedTimestamp()
+	require.False(t, ok, "should not initialize when start timestamp validation fails")
 }
 
 func TestAdvanceValidation_AdvancesTimestamp(t *testing.T) {

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -422,8 +422,9 @@ func (c *LogsDBChainIngester) runIngestion() {
 			continue
 		}
 
-		// Reorg detection: if head moved behind our progress, check hash
-		if head.NumberU64() < nextBlock-1 {
+		// Reorg detection: if head is at or behind our progress, verify hash at that height.
+		// This catches same-height reorgs where the head block was replaced without height decrease.
+		if head.NumberU64() <= nextBlock-1 {
 			if err := c.checkReorg(head); err != nil {
 				continue
 			}

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -447,16 +447,15 @@ func (c *LogsDBChainIngester) runIngestion() {
 			}
 			nextBlock++
 
-			lastLogTime = c.maybeLogProgress(nextBlock, head.NumberU64(), lastLogTime)
+			if clock.SystemClock.Since(lastLogTime) > progressLogInterval {
+				c.logProgress(nextBlock, head.NumberU64())
+				lastLogTime = clock.SystemClock.Now()
+			}
 		}
 	}
 }
 
-func (c *LogsDBChainIngester) maybeLogProgress(nextBlock uint64, headNumber uint64, lastLogTime time.Time) time.Time {
-	if clock.SystemClock.Since(lastLogTime) <= progressLogInterval {
-		return lastLogTime
-	}
-
+func (c *LogsDBChainIngester) logProgress(nextBlock uint64, headNumber uint64) {
 	startingBlock := c.calculateStartingBlock()
 	if nextBlock <= startingBlock {
 		progress := float64(nextBlock-c.earliestIngestedBlock.Load()) / float64(startingBlock-c.earliestIngestedBlock.Load()+1)
@@ -469,8 +468,6 @@ func (c *LogsDBChainIngester) maybeLogProgress(nextBlock uint64, headNumber uint
 	} else {
 		c.log.Debug("Ingestion progress", "block", nextBlock-1, "head", headNumber)
 	}
-
-	return clock.SystemClock.Now()
 }
 
 // initIngestion performs one-time setup and returns the first block to ingest.

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -380,6 +380,7 @@ func (c *LogsDBChainIngester) initLogsDB() error {
 func (c *LogsDBChainIngester) runIngestion() {
 	defer c.wg.Done()
 
+	// One-time setup: determine starting block and next block to ingest
 	nextBlock, err := c.initIngestion()
 	if err != nil {
 		// Application context was canceled (e.g., during shutdown).
@@ -391,11 +392,13 @@ func (c *LogsDBChainIngester) runIngestion() {
 		return
 	}
 
+	// Track progress for logging
 	lastLogTime := clock.SystemClock.Now()
 
 	ticker := time.NewTicker(c.pollInterval)
 	defer ticker.Stop()
 
+	// Ingestion loop
 	for {
 		select {
 		case <-c.ctx.Done():
@@ -444,24 +447,30 @@ func (c *LogsDBChainIngester) runIngestion() {
 			}
 			nextBlock++
 
-			// Progress logging
-			if clock.SystemClock.Since(lastLogTime) > progressLogInterval {
-				startingBlock := c.calculateStartingBlock()
-				if nextBlock <= startingBlock {
-					progress := float64(nextBlock-c.earliestIngestedBlock.Load()) / float64(startingBlock-c.earliestIngestedBlock.Load()+1)
-					c.log.Info("Ingestion progress",
-						"block", nextBlock-1,
-						"target", startingBlock,
-						"progress", fmt.Sprintf("%.0f%%", progress*100))
-					chainIDUint64, _ := c.chainID.Uint64()
-					c.metrics.RecordBackfillProgress(chainIDUint64, progress)
-				} else {
-					c.log.Debug("Ingestion progress", "block", nextBlock-1, "head", head.NumberU64())
-				}
-				lastLogTime = clock.SystemClock.Now()
-			}
+			lastLogTime = c.maybeLogProgress(nextBlock, head.NumberU64(), lastLogTime)
 		}
 	}
+}
+
+func (c *LogsDBChainIngester) maybeLogProgress(nextBlock uint64, headNumber uint64, lastLogTime time.Time) time.Time {
+	if clock.SystemClock.Since(lastLogTime) <= progressLogInterval {
+		return lastLogTime
+	}
+
+	startingBlock := c.calculateStartingBlock()
+	if nextBlock <= startingBlock {
+		progress := float64(nextBlock-c.earliestIngestedBlock.Load()) / float64(startingBlock-c.earliestIngestedBlock.Load()+1)
+		c.log.Info("Ingestion progress",
+			"block", nextBlock-1,
+			"target", startingBlock,
+			"progress", fmt.Sprintf("%.0f%%", progress*100))
+		chainIDUint64, _ := c.chainID.Uint64()
+		c.metrics.RecordBackfillProgress(chainIDUint64, progress)
+	} else {
+		c.log.Debug("Ingestion progress", "block", nextBlock-1, "head", headNumber)
+	}
+
+	return clock.SystemClock.Now()
 }
 
 // initIngestion performs one-time setup and returns the first block to ingest.

--- a/op-interop-filter/filter/logsdb_chain_ingester.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester.go
@@ -380,7 +380,6 @@ func (c *LogsDBChainIngester) initLogsDB() error {
 func (c *LogsDBChainIngester) runIngestion() {
 	defer c.wg.Done()
 
-	// One-time setup: determine starting block and next block to ingest
 	nextBlock, err := c.initIngestion()
 	if err != nil {
 		// Application context was canceled (e.g., during shutdown).
@@ -392,14 +391,11 @@ func (c *LogsDBChainIngester) runIngestion() {
 		return
 	}
 
-	// Track progress for logging
 	lastLogTime := clock.SystemClock.Now()
 
-	// Use ticker for polling interval
 	ticker := time.NewTicker(c.pollInterval)
 	defer ticker.Stop()
 
-	// Unified ingestion loop - no concept of "backfill" vs "live"
 	for {
 		select {
 		case <-c.ctx.Done():
@@ -422,9 +418,8 @@ func (c *LogsDBChainIngester) runIngestion() {
 			continue
 		}
 
-		// Reorg detection: if head is at or behind our progress, verify hash at that height.
-		// This catches same-height reorgs where the head block was replaced without height decrease.
-		if head.NumberU64() <= nextBlock-1 {
+		// Verify canonical hash when head is behind the next block to ingest.
+		if head.NumberU64() < nextBlock {
 			if err := c.checkReorg(head); err != nil {
 				continue
 			}
@@ -466,7 +461,6 @@ func (c *LogsDBChainIngester) runIngestion() {
 				lastLogTime = clock.SystemClock.Now()
 			}
 		}
-		// Caught up to head, will wait for next ticker tick
 	}
 }
 

--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -448,6 +448,71 @@ func TestLogsDBChainIngester_ReorgDetection(t *testing.T) {
 	require.Equal(t, ErrorReorg, ingesterErr.Reason)
 }
 
+func TestLogsDBChainIngester_DetectsSameHeightReorgInRunLoop(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	tempDir := t.TempDir()
+
+	mockClient := NewMockEthClient()
+
+	parent := &mockBlockInfo{
+		number:     99,
+		hash:       common.Hash{0x99},
+		parentHash: common.Hash{0x55},
+		timestamp:  1198,
+	}
+	originalHead := &mockBlockInfo{
+		number:     100,
+		hash:       common.Hash{0xAA},
+		parentHash: parent.Hash(),
+		timestamp:  1200,
+	}
+	reorgedHead := &mockBlockInfo{
+		number:     100,
+		hash:       common.Hash{0xBB}, // same height, different hash
+		parentHash: parent.Hash(),
+		timestamp:  1200,
+	}
+
+	// Build DB state from original canonical head.
+	mockClient.AddBlock(parent, nil)
+	mockClient.AddBlock(originalHead, nil)
+	mockClient.SetHeadBlock(originalHead)
+
+	seedIngester := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   tempDir,
+		ethClient: mockClient,
+		rollupCfg: testRollupConfig(901, 0, 1000),
+	})
+	err := seedIngester.initLogsDB()
+	require.NoError(t, err)
+	err = seedIngester.sealParentBlock(99)
+	require.NoError(t, err)
+	err = seedIngester.ingestBlock(100)
+	require.NoError(t, err)
+	require.NoError(t, seedIngester.logsDB.Close())
+
+	// Same-height reorg: head block number stays 100 but hash changes.
+	mockClient.AddBlock(reorgedHead, nil) // overwrite block 100 by number
+	mockClient.SetHeadBlock(reorgedHead)
+
+	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
+		chainID:   chainID,
+		dataDir:   tempDir,
+		ethClient: mockClient,
+		rollupCfg: testRollupConfig(901, 0, 1000),
+	})
+	ingester.pollInterval = 10 * time.Millisecond
+
+	require.NoError(t, ingester.Start())
+	t.Cleanup(func() { _ = ingester.Stop() })
+
+	require.Eventually(t, func() bool {
+		ingesterErr := ingester.Error()
+		return ingesterErr != nil && ingesterErr.Reason == ErrorReorg
+	}, 300*time.Millisecond, 10*time.Millisecond, "run loop should detect same-height reorg")
+}
+
 func TestLogsDBChainIngester_QueryMethods(t *testing.T) {
 	chainID := eth.ChainIDFromUInt64(901)
 	tempDir := t.TempDir()

--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -406,111 +406,108 @@ func TestLogsDBChainIngester_Contains(t *testing.T) {
 }
 
 func TestLogsDBChainIngester_ReorgDetection(t *testing.T) {
-	chainID := eth.ChainIDFromUInt64(901)
-	tempDir := t.TempDir()
+	t.Run("parent-hash mismatch in ingestBlock", func(t *testing.T) {
+		chainID := eth.ChainIDFromUInt64(901)
+		tempDir := t.TempDir()
 
-	mockClient := NewMockEthClient()
+		mockClient := NewMockEthClient()
 
-	// Create blocks
-	parentBlock := createTestBlock(99, 1198, common.Hash{})
-	mockClient.AddBlock(parentBlock, nil)
+		parentBlock := createTestBlock(99, 1198, common.Hash{})
+		mockClient.AddBlock(parentBlock, nil)
 
-	block100 := createTestBlock(100, 1200, parentBlock.Hash())
-	mockClient.AddBlock(block100, createTestReceipts(100, 1))
+		block100 := createTestBlock(100, 1200, parentBlock.Hash())
+		mockClient.AddBlock(block100, createTestReceipts(100, 1))
 
-	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
-		chainID:   chainID,
-		dataDir:   tempDir,
-		ethClient: mockClient,
-		rollupCfg: testRollupConfig(901, 0, 1000),
-	})
+		ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
+			chainID:   chainID,
+			dataDir:   tempDir,
+			ethClient: mockClient,
+			rollupCfg: testRollupConfig(901, 0, 1000),
+		})
 
-	err := ingester.initLogsDB()
-	require.NoError(t, err)
-	t.Cleanup(func() { ingester.logsDB.Close() })
+		err := ingester.initLogsDB()
+		require.NoError(t, err)
+		t.Cleanup(func() { ingester.logsDB.Close() })
 
-	err = ingester.sealParentBlock(99)
-	require.NoError(t, err)
+		err = ingester.sealParentBlock(99)
+		require.NoError(t, err)
 
-	err = ingester.ingestBlock(100)
-	require.NoError(t, err)
+		err = ingester.ingestBlock(100)
+		require.NoError(t, err)
 
-	// Now try to ingest a block with wrong parent hash (simulating a reorg)
-	reorgBlock := createTestBlock(101, 1202, common.Hash{0xDE, 0xAD}) // Wrong parent
-	mockClient.AddBlock(reorgBlock, createTestReceipts(101, 1))
+		reorgBlock := createTestBlock(101, 1202, common.Hash{0xDE, 0xAD})
+		mockClient.AddBlock(reorgBlock, createTestReceipts(101, 1))
 
-	err = ingester.ingestBlock(101)
-	require.NoError(t, err) // ingestBlock doesn't return error, it sets error state
+		err = ingester.ingestBlock(101)
+		require.NoError(t, err)
 
-	// Check that error state was set
-	ingesterErr := ingester.Error()
-	require.NotNil(t, ingesterErr)
-	require.Equal(t, ErrorReorg, ingesterErr.Reason)
-}
-
-func TestLogsDBChainIngester_DetectsSameHeightReorgInRunLoop(t *testing.T) {
-	chainID := eth.ChainIDFromUInt64(901)
-	tempDir := t.TempDir()
-
-	mockClient := NewMockEthClient()
-
-	parent := &mockBlockInfo{
-		number:     99,
-		hash:       common.Hash{0x99},
-		parentHash: common.Hash{0x55},
-		timestamp:  1198,
-	}
-	originalHead := &mockBlockInfo{
-		number:     100,
-		hash:       common.Hash{0xAA},
-		parentHash: parent.Hash(),
-		timestamp:  1200,
-	}
-	reorgedHead := &mockBlockInfo{
-		number:     100,
-		hash:       common.Hash{0xBB}, // same height, different hash
-		parentHash: parent.Hash(),
-		timestamp:  1200,
-	}
-
-	// Build DB state from original canonical head.
-	mockClient.AddBlock(parent, nil)
-	mockClient.AddBlock(originalHead, nil)
-	mockClient.SetHeadBlock(originalHead)
-
-	seedIngester := newTestLogsDBChainIngester(t, testIngesterConfig{
-		chainID:   chainID,
-		dataDir:   tempDir,
-		ethClient: mockClient,
-		rollupCfg: testRollupConfig(901, 0, 1000),
-	})
-	err := seedIngester.initLogsDB()
-	require.NoError(t, err)
-	err = seedIngester.sealParentBlock(99)
-	require.NoError(t, err)
-	err = seedIngester.ingestBlock(100)
-	require.NoError(t, err)
-	require.NoError(t, seedIngester.logsDB.Close())
-
-	// Same-height reorg: head block number stays 100 but hash changes.
-	mockClient.AddBlock(reorgedHead, nil) // overwrite block 100 by number
-	mockClient.SetHeadBlock(reorgedHead)
-
-	ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
-		chainID:   chainID,
-		dataDir:   tempDir,
-		ethClient: mockClient,
-		rollupCfg: testRollupConfig(901, 0, 1000),
-	})
-	ingester.pollInterval = 10 * time.Millisecond
-
-	require.NoError(t, ingester.Start())
-	t.Cleanup(func() { _ = ingester.Stop() })
-
-	require.Eventually(t, func() bool {
 		ingesterErr := ingester.Error()
-		return ingesterErr != nil && ingesterErr.Reason == ErrorReorg
-	}, 300*time.Millisecond, 10*time.Millisecond, "run loop should detect same-height reorg")
+		require.NotNil(t, ingesterErr)
+		require.Equal(t, ErrorReorg, ingesterErr.Reason)
+	})
+
+	t.Run("same-height reorg in run loop", func(t *testing.T) {
+		chainID := eth.ChainIDFromUInt64(901)
+		tempDir := t.TempDir()
+
+		mockClient := NewMockEthClient()
+
+		parent := &mockBlockInfo{
+			number:     99,
+			hash:       common.Hash{0x99},
+			parentHash: common.Hash{0x55},
+			timestamp:  1198,
+		}
+		originalHead := &mockBlockInfo{
+			number:     100,
+			hash:       common.Hash{0xAA},
+			parentHash: parent.Hash(),
+			timestamp:  1200,
+		}
+		reorgedHead := &mockBlockInfo{
+			number:     100,
+			hash:       common.Hash{0xBB},
+			parentHash: parent.Hash(),
+			timestamp:  1200,
+		}
+
+		mockClient.AddBlock(parent, nil)
+		mockClient.AddBlock(originalHead, nil)
+		mockClient.SetHeadBlock(originalHead)
+
+		seedIngester := newTestLogsDBChainIngester(t, testIngesterConfig{
+			chainID:   chainID,
+			dataDir:   tempDir,
+			ethClient: mockClient,
+			rollupCfg: testRollupConfig(901, 0, 1000),
+		})
+		err := seedIngester.initLogsDB()
+		require.NoError(t, err)
+		err = seedIngester.sealParentBlock(99)
+		require.NoError(t, err)
+		err = seedIngester.ingestBlock(100)
+		require.NoError(t, err)
+		require.NoError(t, seedIngester.logsDB.Close())
+
+		mockClient.AddBlock(reorgedHead, nil)
+		mockClient.SetHeadBlock(reorgedHead)
+
+		ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
+			chainID:   chainID,
+			dataDir:   tempDir,
+			ethClient: mockClient,
+			rollupCfg: testRollupConfig(901, 0, 1000),
+		})
+		ingester.pollInterval = 10 * time.Millisecond
+
+		require.NoError(t, ingester.Start())
+		t.Cleanup(func() { _ = ingester.Stop() })
+
+		require.Eventually(t, func() bool {
+			ingesterErr := ingester.Error()
+			return ingesterErr != nil && ingesterErr.Reason == ErrorReorg
+		}, 300*time.Millisecond, 10*time.Millisecond, "run loop should detect same-height reorg")
+	})
 }
 
 func TestLogsDBChainIngester_QueryMethods(t *testing.T) {

--- a/op-interop-filter/filter/logsdb_chain_ingester_test.go
+++ b/op-interop-filter/filter/logsdb_chain_ingester_test.go
@@ -406,8 +406,31 @@ func TestLogsDBChainIngester_Contains(t *testing.T) {
 }
 
 func TestLogsDBChainIngester_ReorgDetection(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	rollupCfg := testRollupConfig(901, 0, 1000)
+
+	newIngester := func(t *testing.T, dataDir string, mockClient *MockEthClient) *LogsDBChainIngester {
+		t.Helper()
+		return newTestLogsDBChainIngester(t, testIngesterConfig{
+			chainID:   chainID,
+			dataDir:   dataDir,
+			ethClient: mockClient,
+			rollupCfg: rollupCfg,
+		})
+	}
+
+	initDB := func(t *testing.T, ingester *LogsDBChainIngester) {
+		t.Helper()
+		require.NoError(t, ingester.initLogsDB())
+	}
+
+	seedToBlock100 := func(t *testing.T, ingester *LogsDBChainIngester) {
+		t.Helper()
+		require.NoError(t, ingester.sealParentBlock(99))
+		require.NoError(t, ingester.ingestBlock(100))
+	}
+
 	t.Run("parent-hash mismatch in ingestBlock", func(t *testing.T) {
-		chainID := eth.ChainIDFromUInt64(901)
 		tempDir := t.TempDir()
 
 		mockClient := NewMockEthClient()
@@ -418,27 +441,15 @@ func TestLogsDBChainIngester_ReorgDetection(t *testing.T) {
 		block100 := createTestBlock(100, 1200, parentBlock.Hash())
 		mockClient.AddBlock(block100, createTestReceipts(100, 1))
 
-		ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
-			chainID:   chainID,
-			dataDir:   tempDir,
-			ethClient: mockClient,
-			rollupCfg: testRollupConfig(901, 0, 1000),
-		})
-
-		err := ingester.initLogsDB()
-		require.NoError(t, err)
+		ingester := newIngester(t, tempDir, mockClient)
+		initDB(t, ingester)
 		t.Cleanup(func() { ingester.logsDB.Close() })
-
-		err = ingester.sealParentBlock(99)
-		require.NoError(t, err)
-
-		err = ingester.ingestBlock(100)
-		require.NoError(t, err)
+		seedToBlock100(t, ingester)
 
 		reorgBlock := createTestBlock(101, 1202, common.Hash{0xDE, 0xAD})
 		mockClient.AddBlock(reorgBlock, createTestReceipts(101, 1))
 
-		err = ingester.ingestBlock(101)
+		err := ingester.ingestBlock(101)
 		require.NoError(t, err)
 
 		ingesterErr := ingester.Error()
@@ -447,7 +458,6 @@ func TestLogsDBChainIngester_ReorgDetection(t *testing.T) {
 	})
 
 	t.Run("same-height reorg in run loop", func(t *testing.T) {
-		chainID := eth.ChainIDFromUInt64(901)
 		tempDir := t.TempDir()
 
 		mockClient := NewMockEthClient()
@@ -475,29 +485,15 @@ func TestLogsDBChainIngester_ReorgDetection(t *testing.T) {
 		mockClient.AddBlock(originalHead, nil)
 		mockClient.SetHeadBlock(originalHead)
 
-		seedIngester := newTestLogsDBChainIngester(t, testIngesterConfig{
-			chainID:   chainID,
-			dataDir:   tempDir,
-			ethClient: mockClient,
-			rollupCfg: testRollupConfig(901, 0, 1000),
-		})
-		err := seedIngester.initLogsDB()
-		require.NoError(t, err)
-		err = seedIngester.sealParentBlock(99)
-		require.NoError(t, err)
-		err = seedIngester.ingestBlock(100)
-		require.NoError(t, err)
+		seedIngester := newIngester(t, tempDir, mockClient)
+		initDB(t, seedIngester)
+		seedToBlock100(t, seedIngester)
 		require.NoError(t, seedIngester.logsDB.Close())
 
 		mockClient.AddBlock(reorgedHead, nil)
 		mockClient.SetHeadBlock(reorgedHead)
 
-		ingester := newTestLogsDBChainIngester(t, testIngesterConfig{
-			chainID:   chainID,
-			dataDir:   tempDir,
-			ethClient: mockClient,
-			rollupCfg: testRollupConfig(901, 0, 1000),
-		})
+		ingester := newIngester(t, tempDir, mockClient)
 		ingester.pollInterval = 10 * time.Millisecond
 
 		require.NoError(t, ingester.Start())


### PR DESCRIPTION
## Summary
Fix a safety gap in `LogsDBChainIngester.runIngestion` where same-height reorgs were not detected promptly.

## Problem
Reorg detection was guarded by `if head.NumberU64() < nextBlock-1`. That misses the case where canonical head is replaced at the same height (hash changes, height unchanged), so hash verification was skipped until head advanced.

## Fix
- Change the run-loop guard to `<=` so hash verification runs when head is at or behind ingested progress.
- Add a regression test that seeds DB with block 100 hash A, swaps canonical head to block 100 hash B, then asserts the run loop reports `ErrorReorg` without waiting for a height increase.

## Security impact
This closes a false-acceptance window for same-height reorg scenarios by ensuring canonical hash consistency is checked immediately at equal height.

## Scope
Only reorg detection behavior is changed. No admin RPC or config logic is modified.

## Testing
- `go test ./op-interop-filter/filter -run DetectsSameHeightReorgInRunLoop -count=1`
- `go test ./op-interop-filter/...`
