### PR TITLE
backup: cursor-based ReverseIter for VerifiedBlockAtL1

### DIFF
--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -458,6 +458,12 @@ func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint6
 // which guarantees that the verified data at that pauseAtTimestamp
 // originates from or before the supplied L1 block.
 func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64) {
+	// If L1 block is empty/zero (e.g. during startup before FinalizedL1 is set),
+	// no verified result can match, so return early.
+	if l1Block == (eth.L1BlockRef{}) {
+		return eth.BlockID{}, 0
+	}
+
 	// Get the last verified timestamp
 	lastTs, ok := i.verifiedDB.LastTimestamp()
 	if !ok {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -458,8 +458,7 @@ func (i *Interop) LatestVerifiedL2Block(chainID eth.ChainID) (eth.BlockID, uint6
 // which guarantees that the verified data at that pauseAtTimestamp
 // originates from or before the supplied L1 block.
 func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef) (eth.BlockID, uint64) {
-	// If L1 block is empty/zero (e.g. during startup before FinalizedL1 is set),
-	// no verified result can match, so return early.
+	// If L1 block is empty/zero, nothing can match
 	if l1Block == (eth.L1BlockRef{}) {
 		return eth.BlockID{}, 0
 	}
@@ -470,28 +469,26 @@ func (i *Interop) VerifiedBlockAtL1(chainID eth.ChainID, l1Block eth.L1BlockRef)
 		return eth.BlockID{}, 0
 	}
 
-	// Search backwards from the last timestamp to find the latest result
+	// Search backwards over actual DB entries to find the latest result
 	// where the L1 inclusion block is at or below the supplied L1 block number
-	for ts := lastTs; ts > 0; ts-- {
-		result, err := i.verifiedDB.Get(ts)
-		if err != nil {
-			// Timestamp might not exist (due to gaps or rewinds), continue searching
-			continue
-		}
-
-		// Check if this result's L1 inclusion is at or below the supplied L1 block number
+	var foundID eth.BlockID
+	var foundTs uint64
+	err := i.verifiedDB.ReverseIter(lastTs, func(ts uint64, result VerifiedResult) bool {
 		if result.L1Inclusion.Number <= l1Block.Number {
-			// Found a finalized result, return the L2 head for this chain
 			head, ok := result.L2Heads[chainID]
 			if !ok {
-				return eth.BlockID{}, 0
+				return false // stop, chain not in this result
 			}
-			return head, ts
+			foundID = head
+			foundTs = ts
+			return false // found it, stop
 		}
+		return true // keep searching
+	})
+	if err != nil {
+		return eth.BlockID{}, 0
 	}
-
-	// No verified block found
-	return eth.BlockID{}, 0
+	return foundID, foundTs
 }
 
 // Reset is called when a chain container resets due to an invalidated block.

--- a/op-supernode/supernode/activity/interop/verified_db.go
+++ b/op-supernode/supernode/activity/interop/verified_db.go
@@ -127,6 +127,39 @@ func (v *VerifiedDB) Commit(result VerifiedResult) error {
 	return nil
 }
 
+// ReverseIter iterates backwards over actual entries in the DB starting from startTs.
+// The callback receives each timestamp and result. Return false to stop iteration.
+func (v *VerifiedDB) ReverseIter(startTs uint64, fn func(ts uint64, result VerifiedResult) bool) error {
+	return v.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketName)
+		c := b.Cursor()
+
+		// Seek to startTs or the nearest key before it
+		seekKey := timestampToKey(startTs)
+		k, val := c.Seek(seekKey)
+		// If Seek landed past startTs, go back one
+		if k != nil && binary.BigEndian.Uint64(k) > startTs {
+			k, val = c.Prev()
+		}
+		// If Seek returned nil (startTs is past all keys), start from the last key
+		if k == nil {
+			k, val = c.Last()
+		}
+
+		for ; k != nil && len(k) == u64Len; k, val = c.Prev() {
+			ts := binary.BigEndian.Uint64(k)
+			var result VerifiedResult
+			if err := json.Unmarshal(val, &result); err != nil {
+				continue
+			}
+			if !fn(ts, result) {
+				return nil
+			}
+		}
+		return nil
+	})
+}
+
 // Get retrieves the verified result at the given timestamp.
 func (v *VerifiedDB) Get(ts uint64) (VerifiedResult, error) {
 	key := timestampToKey(ts)


### PR DESCRIPTION
Backup branch with the full cursor-based iteration approach (zero check + ReverseIter).

This is the alternative to the minimal fix in #33 / ethereum-optimism/optimism#19405. Includes:
- Zero l1Block early return
- `ReverseIter` method on `VerifiedDB` using BoltDB cursor
- `VerifiedBlockAtL1` rewritten to use `ReverseIter` instead of timestamp-decrement loop

Kept for reference in case we want the cursor approach later (e.g. if the sequential-no-gaps invariant changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)