### PR TITLE
fix(op-supernode): respect genesis block offset in timestamp conversion

### DIFF
--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -315,7 +315,10 @@ func (c *simpleChainContainer) BlockNumberToTimestamp(ctx context.Context, block
 	if c.vncfg == nil {
 		return 0, fmt.Errorf("rollup config not available")
 	}
-	return c.vncfg.Rollup.Genesis.L2Time + (blocknum * c.vncfg.Rollup.BlockTime), nil
+	if blocknum < c.vncfg.Rollup.Genesis.L2.Number {
+		return 0, fmt.Errorf("block number %d before genesis %d", blocknum, c.vncfg.Rollup.Genesis.L2.Number)
+	}
+	return c.vncfg.Rollup.TimestampForBlock(blocknum), nil
 }
 
 // LocalSafeBlockAtTimestamp returns the highest L2 block with timestamp <= ts using the L2 client,
@@ -571,5 +574,8 @@ func (c *simpleChainContainer) blockNumberToTimestamp(blockNum uint64) uint64 {
 	if c.vncfg == nil {
 		return 0
 	}
-	return c.vncfg.Rollup.Genesis.L2Time + (blockNum * c.vncfg.Rollup.BlockTime)
+	if blockNum < c.vncfg.Rollup.Genesis.L2.Number {
+		return 0
+	}
+	return c.vncfg.Rollup.TimestampForBlock(blockNum)
 }

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -1098,3 +1098,29 @@ func TestChainContainer_LocalSafeBlockAtTimestamp(t *testing.T) {
 		})
 	}
 }
+
+func TestChainContainer_BlockNumberToTimestamp_RespectsGenesisBlockNumber(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(420)
+	log := createTestLogger(t)
+	cfg := createTestCLIConfig(t.TempDir())
+	initOverload := &rollupNode.InitializationOverrides{}
+
+	vncfg := createTestVNConfig()
+	vncfg.Rollup.Genesis.L2Time = 1000
+	vncfg.Rollup.Genesis.L2.Number = 100
+	vncfg.Rollup.BlockTime = 2
+
+	container := NewChainContainer(chainID, vncfg, log, cfg, initOverload, nil, nil, nil)
+	impl, ok := container.(*simpleChainContainer)
+	require.True(t, ok)
+
+	timestamp, err := impl.BlockNumberToTimestamp(context.Background(), 104)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1008), timestamp)
+
+	_, err = impl.BlockNumberToTimestamp(context.Background(), 99)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "before genesis 100")
+}

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -350,6 +350,7 @@ func TestInvalidateBlock(t *testing.T) {
 
 	tests := []struct {
 		name             string
+		genesisBlock     uint64
 		height           uint64
 		payloadHash      common.Hash
 		currentBlockHash common.Hash
@@ -359,6 +360,7 @@ func TestInvalidateBlock(t *testing.T) {
 	}{
 		{
 			name:             "current block matches triggers rewind",
+			genesisBlock:     0,
 			height:           5,
 			payloadHash:      common.HexToHash("0xdead"),
 			currentBlockHash: common.HexToHash("0xdead"), // Same hash
@@ -368,6 +370,7 @@ func TestInvalidateBlock(t *testing.T) {
 		},
 		{
 			name:             "current block differs no rewind",
+			genesisBlock:     0,
 			height:           5,
 			payloadHash:      common.HexToHash("0xdead"),
 			currentBlockHash: common.HexToHash("0xbeef"), // Different hash
@@ -376,6 +379,7 @@ func TestInvalidateBlock(t *testing.T) {
 		},
 		{
 			name:            "engine unavailable adds to denylist only",
+			genesisBlock:    0,
 			height:          5,
 			payloadHash:     common.HexToHash("0xdead"),
 			engineAvailable: false,
@@ -383,12 +387,23 @@ func TestInvalidateBlock(t *testing.T) {
 		},
 		{
 			name:             "rewind to height-1 timestamp calculated correctly",
+			genesisBlock:     0,
 			height:           10,
 			payloadHash:      common.HexToHash("0xabcd"),
 			currentBlockHash: common.HexToHash("0xabcd"),
 			engineAvailable:  true,
 			expectRewind:     true,
 			expectRewindTs:   genesisTime + (9 * blockTime), // height 9
+		},
+		{
+			name:             "rewind timestamp respects nonzero genesis block number",
+			genesisBlock:     100,
+			height:           105,
+			payloadHash:      common.HexToHash("0xcafe"),
+			currentBlockHash: common.HexToHash("0xcafe"),
+			engineAvailable:  true,
+			expectRewind:     true,
+			expectRewindTs:   genesisTime + (4 * blockTime), // block 104 relative to genesis block 100
 		},
 	}
 
@@ -442,6 +457,7 @@ func TestInvalidateBlock(t *testing.T) {
 				vn:       &mockVNForInvalidation{},
 			}
 			c.vncfg.Rollup.Genesis.L2Time = genesisTime
+			c.vncfg.Rollup.Genesis.L2.Number = tt.genesisBlock
 			c.vncfg.Rollup.BlockTime = blockTime
 
 			if tt.engineAvailable {


### PR DESCRIPTION
Closes ethereum-optimism/optimism#19540

## Summary
- use the canonical rollup timestamp mapping for block-number-to-timestamp conversion in `simpleChainContainer`
- guard against block numbers below `Genesis.L2.Number` before calling the rollup helper
- add regressions for direct conversion and invalidation-triggered rewind targeting when the L2 genesis block number is nonzero

## Testing
- `./linter/bin/op-golangci-lint run ./op-supernode/...`
- `go test ./op-supernode/...`