### PR TITLE
op-interop-filter: add sender allow-listing

### DIFF
--- a/op-acceptance-tests/tests/interop/upgrade/pre_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/pre_test.go
@@ -105,7 +105,7 @@ func TestPreNoInbox(gt *testing.T) {
 		accessEntries := []stypes.Access{execTrigger.Msg.Access()}
 		accessList := stypes.EncodeAccessList(accessEntries)
 
-		err = sys.Supervisor.Escape().QueryAPI().CheckAccessList(ctx, accessList, stypes.CrossSafe, ed)
+		err = sys.Supervisor.Escape().QueryAPI().CheckAccessList(ctx, accessList, stypes.CrossSafe, ed, common.Address{})
 		require.ErrorContains(err, "conflicting data")
 	}
 

--- a/op-acceptance-tests/tests/interop/upgrade/pre_test.go
+++ b/op-acceptance-tests/tests/interop/upgrade/pre_test.go
@@ -105,7 +105,7 @@ func TestPreNoInbox(gt *testing.T) {
 		accessEntries := []stypes.Access{execTrigger.Msg.Access()}
 		accessList := stypes.EncodeAccessList(accessEntries)
 
-		err = sys.Supervisor.Escape().QueryAPI().CheckAccessList(ctx, accessList, stypes.CrossSafe, ed, common.Address{})
+		err = sys.Supervisor.Escape().QueryAPI().CheckAccessList(ctx, accessList, stypes.CrossSafe, ed, nil)
 		require.ErrorContains(err, "conflicting data")
 	}
 

--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -237,13 +237,13 @@ func TestInterop_EmitLogs(t *testing.T) {
 		timestamp := uint64(time.Now().Unix())
 		ed := types.ExecutingDescriptor{Timestamp: timestamp, ChainID: eth.ChainIDFromBig(s2.ChainID(chainB))}
 		ctx = context.Background()
-		err = supervisor.CheckAccessList(ctx, accessList, types.CrossSafe, ed)
+		err = supervisor.CheckAccessList(ctx, accessList, types.CrossSafe, ed, common.Address{})
 		require.NoError(t, err, "logsA must all be cross-safe")
 
 		// a log should be invalid if the timestamp is incorrect
 		accessEntries[0].Timestamp = 333
 		accessList = types.EncodeAccessList(accessEntries)
-		err = supervisor.CheckAccessList(ctx, accessList, types.CrossSafe, ed)
+		err = supervisor.CheckAccessList(ctx, accessList, types.CrossSafe, ed, common.Address{})
 		require.ErrorContains(t, err, "conflict")
 	}
 	config := SuperSystemConfig{

--- a/op-e2e/interop/interop_test.go
+++ b/op-e2e/interop/interop_test.go
@@ -237,13 +237,13 @@ func TestInterop_EmitLogs(t *testing.T) {
 		timestamp := uint64(time.Now().Unix())
 		ed := types.ExecutingDescriptor{Timestamp: timestamp, ChainID: eth.ChainIDFromBig(s2.ChainID(chainB))}
 		ctx = context.Background()
-		err = supervisor.CheckAccessList(ctx, accessList, types.CrossSafe, ed, common.Address{})
+		err = supervisor.CheckAccessList(ctx, accessList, types.CrossSafe, ed, nil)
 		require.NoError(t, err, "logsA must all be cross-safe")
 
 		// a log should be invalid if the timestamp is incorrect
 		accessEntries[0].Timestamp = 333
 		accessList = types.EncodeAccessList(accessEntries)
-		err = supervisor.CheckAccessList(ctx, accessList, types.CrossSafe, ed, common.Address{})
+		err = supervisor.CheckAccessList(ctx, accessList, types.CrossSafe, ed, nil)
 		require.ErrorContains(t, err, "conflict")
 	}
 	config := SuperSystemConfig{

--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -30,7 +30,8 @@ type Backend struct {
 	manualFailsafe atomic.Bool
 
 	// Passthrough mode: all transactions pass without filtering
-	passthrough bool
+	passthrough  bool
+	senderPolicy *SenderPolicy
 
 	cancel context.CancelFunc
 }
@@ -42,6 +43,7 @@ type BackendParams struct {
 	Chains         map[eth.ChainID]ChainIngester
 	CrossValidator CrossValidator
 	Passthrough    bool
+	SenderPolicy   *SenderPolicy
 }
 
 // NewBackend creates a new Backend instance with the provided components.
@@ -54,6 +56,7 @@ func NewBackend(parentCtx context.Context, params BackendParams) *Backend {
 		chains:         params.Chains,
 		crossValidator: params.CrossValidator,
 		passthrough:    params.Passthrough,
+		senderPolicy:   params.SenderPolicy,
 		cancel:         cancel,
 	}
 }
@@ -136,7 +139,7 @@ func supportedSafetyLevel(level types.SafetyLevel) bool {
 
 // CheckAccessList validates the given access list entries.
 func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, execDescriptor types.ExecutingDescriptor) error {
+	minSafety types.SafetyLevel, execDescriptor types.ExecutingDescriptor, sender common.Address) error {
 
 	if b.passthrough {
 		b.metrics.RecordCheckAccessList(true)
@@ -162,6 +165,12 @@ func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Has
 	if _, ok := b.chains[execDescriptor.ChainID]; !ok {
 		b.metrics.RecordCheckAccessList(false)
 		return fmt.Errorf("executing chain %s: %w", execDescriptor.ChainID, types.ErrUnknownChain)
+	}
+
+	if !b.senderPolicy.Allows(sender) {
+		b.log.Debug("Rejecting interop tx from unauthorized sender", "sender", sender)
+		b.metrics.RecordCheckAccessList(false)
+		return fmt.Errorf("%w: %s", types.ErrUnauthorizedSender, sender)
 	}
 
 	remaining := inboxEntries

--- a/op-interop-filter/filter/backend.go
+++ b/op-interop-filter/filter/backend.go
@@ -139,7 +139,7 @@ func supportedSafetyLevel(level types.SafetyLevel) bool {
 
 // CheckAccessList validates the given access list entries.
 func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, execDescriptor types.ExecutingDescriptor, sender common.Address) error {
+	minSafety types.SafetyLevel, execDescriptor types.ExecutingDescriptor, sender *common.Address) error {
 
 	if b.passthrough {
 		b.metrics.RecordCheckAccessList(true)
@@ -167,8 +167,12 @@ func (b *Backend) CheckAccessList(ctx context.Context, inboxEntries []common.Has
 		return fmt.Errorf("executing chain %s: %w", execDescriptor.ChainID, types.ErrUnknownChain)
 	}
 
-	if !b.senderPolicy.Allows(sender) {
-		b.log.Debug("Rejecting interop tx from unauthorized sender", "sender", sender)
+	senderAddr := common.Address{}
+	if sender != nil {
+		senderAddr = *sender
+	}
+	if !b.senderPolicy.Allows(senderAddr) {
+		b.log.Debug("Rejecting interop tx from unauthorized sender", "sender", senderAddr)
 		b.metrics.RecordCheckAccessList(false)
 		return fmt.Errorf("%w: %s", types.ErrUnauthorizedSender, sender)
 	}

--- a/op-interop-filter/filter/backend_test.go
+++ b/op-interop-filter/filter/backend_test.go
@@ -204,29 +204,29 @@ func TestBackend_CheckAccessList(t *testing.T) {
 	// Failsafe enabled returns error
 	backend, _ := newTestBackendWithMockChain(testChainA)
 	backend.SetFailsafeEnabled(true)
-	err := backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 100, 0), testAllowedSender)
+	err := backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 100, 0), &testAllowedSender)
 	require.ErrorIs(t, err, types.ErrFailsafeEnabled)
 
 	// Not ready returns error
 	backend = newTestBackend() // No chains = not ready
-	err = backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 100, 0), testAllowedSender)
+	err = backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 100, 0), &testAllowedSender)
 	require.ErrorIs(t, err, types.ErrUninitialized)
 
 	// Unsupported safety level returns error
 	backend, mock := newTestBackendWithMockChain(testChainA)
 	mock.SetReady(true)
-	err = backend.CheckAccessList(context.Background(), nil, types.Finalized, makeExecDescriptor(testChainA, 100, 0), testAllowedSender)
+	err = backend.CheckAccessList(context.Background(), nil, types.Finalized, makeExecDescriptor(testChainA, 100, 0), &testAllowedSender)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported safety level")
 
 	// Unknown executing chain returns error
 	mock.SetLatestTimestamp(200)
 	unknownChainID := uint64(999)
-	err = backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(unknownChainID, 150, 0), testAllowedSender)
+	err = backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(unknownChainID, 150, 0), &testAllowedSender)
 	require.ErrorIs(t, err, types.ErrUnknownChain)
 
 	// LocalUnsafe with empty access list passes
-	err = backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 150, 0), testAllowedSender)
+	err = backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 150, 0), &testAllowedSender)
 	require.NoError(t, err)
 }
 
@@ -236,7 +236,7 @@ func TestBackend_CheckAccessList_RejectsUnauthorizedSender(t *testing.T) {
 	mock.SetLatestTimestamp(200)
 	backend.senderPolicy = mustParseTestSenderPolicy(t, common.HexToAddress("0x9999999999999999999999999999999999999999").Hex())
 
-	err := backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 150, 0), testAllowedSender)
+	err := backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 150, 0), &testAllowedSender)
 	require.ErrorIs(t, err, types.ErrUnauthorizedSender)
 }
 
@@ -246,7 +246,7 @@ func TestBackend_CheckAccessList_AllowsConfiguredSender(t *testing.T) {
 	mock.SetLatestTimestamp(200)
 	backend.senderPolicy = mustParseTestSenderPolicy(t, testAllowedSender.Hex())
 
-	err := backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 150, 0), testAllowedSender)
+	err := backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 150, 0), &testAllowedSender)
 	require.NoError(t, err)
 }
 
@@ -256,6 +256,7 @@ func TestBackend_CheckAccessList_AllowsWildcardSenderPolicy(t *testing.T) {
 	mock.SetLatestTimestamp(200)
 	backend.senderPolicy = mustParseTestSenderPolicy(t, "*")
 
-	err := backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 150, 0), common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+	anySender := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	err := backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 150, 0), &anySender)
 	require.NoError(t, err)
 }

--- a/op-interop-filter/filter/backend_test.go
+++ b/op-interop-filter/filter/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
@@ -20,6 +21,8 @@ const (
 	testChainA       = uint64(900)
 )
 
+var testAllowedSender = common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+
 // =============================================================================
 // Test Helpers
 // =============================================================================
@@ -30,6 +33,7 @@ func newTestBackend() *Backend {
 		Metrics:        metrics.NoopMetrics,
 		Chains:         make(map[eth.ChainID]ChainIngester),
 		CrossValidator: &mockCrossValidator{},
+		SenderPolicy:   AllowAnySenderPolicy(),
 	})
 }
 
@@ -44,6 +48,7 @@ func newTestBackendWithMockChain(chainID uint64) (*Backend, *mockChainIngester) 
 		Metrics:        metrics.NoopMetrics,
 		Chains:         chains,
 		CrossValidator: cv,
+		SenderPolicy:   AllowAnySenderPolicy(),
 	}), mock
 }
 
@@ -199,28 +204,58 @@ func TestBackend_CheckAccessList(t *testing.T) {
 	// Failsafe enabled returns error
 	backend, _ := newTestBackendWithMockChain(testChainA)
 	backend.SetFailsafeEnabled(true)
-	err := backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 100, 0))
+	err := backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 100, 0), testAllowedSender)
 	require.ErrorIs(t, err, types.ErrFailsafeEnabled)
 
 	// Not ready returns error
 	backend = newTestBackend() // No chains = not ready
-	err = backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 100, 0))
+	err = backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 100, 0), testAllowedSender)
 	require.ErrorIs(t, err, types.ErrUninitialized)
 
 	// Unsupported safety level returns error
 	backend, mock := newTestBackendWithMockChain(testChainA)
 	mock.SetReady(true)
-	err = backend.CheckAccessList(context.Background(), nil, types.Finalized, makeExecDescriptor(testChainA, 100, 0))
+	err = backend.CheckAccessList(context.Background(), nil, types.Finalized, makeExecDescriptor(testChainA, 100, 0), testAllowedSender)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported safety level")
 
 	// Unknown executing chain returns error
 	mock.SetLatestTimestamp(200)
 	unknownChainID := uint64(999)
-	err = backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(unknownChainID, 150, 0))
+	err = backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(unknownChainID, 150, 0), testAllowedSender)
 	require.ErrorIs(t, err, types.ErrUnknownChain)
 
 	// LocalUnsafe with empty access list passes
-	err = backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 150, 0))
+	err = backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 150, 0), testAllowedSender)
+	require.NoError(t, err)
+}
+
+func TestBackend_CheckAccessList_RejectsUnauthorizedSender(t *testing.T) {
+	backend, mock := newTestBackendWithMockChain(testChainA)
+	mock.SetReady(true)
+	mock.SetLatestTimestamp(200)
+	backend.senderPolicy = mustParseTestSenderPolicy(t, common.HexToAddress("0x9999999999999999999999999999999999999999").Hex())
+
+	err := backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 150, 0), testAllowedSender)
+	require.ErrorIs(t, err, types.ErrUnauthorizedSender)
+}
+
+func TestBackend_CheckAccessList_AllowsConfiguredSender(t *testing.T) {
+	backend, mock := newTestBackendWithMockChain(testChainA)
+	mock.SetReady(true)
+	mock.SetLatestTimestamp(200)
+	backend.senderPolicy = mustParseTestSenderPolicy(t, testAllowedSender.Hex())
+
+	err := backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 150, 0), testAllowedSender)
+	require.NoError(t, err)
+}
+
+func TestBackend_CheckAccessList_AllowsWildcardSenderPolicy(t *testing.T) {
+	backend, mock := newTestBackendWithMockChain(testChainA)
+	mock.SetReady(true)
+	mock.SetLatestTimestamp(200)
+	backend.senderPolicy = mustParseTestSenderPolicy(t, "*")
+
+	err := backend.CheckAccessList(context.Background(), nil, types.LocalUnsafe, makeExecDescriptor(testChainA, 150, 0), common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
 	require.NoError(t, err)
 }

--- a/op-interop-filter/filter/config.go
+++ b/op-interop-filter/filter/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	PollInterval                time.Duration // Interval for polling new blocks (default: 2s)
 	ValidationInterval          time.Duration // Interval for cross-chain validation (default: 500ms)
 	Passthrough                 bool          // If true, all transactions pass through without filtering
+	AllowedSenders              *SenderPolicy
 
 	LogConfig     oplog.CLIConfig
 	MetricsConfig opmetrics.CLIConfig
@@ -67,6 +68,9 @@ func (c *Config) Check() error {
 	}
 	if c.ValidationInterval <= 0 {
 		result = errors.Join(result, errors.New("validation-interval must be positive"))
+	}
+	if !c.Passthrough && c.AllowedSenders == nil {
+		result = errors.Join(result, errors.New("allowed-senders must be configured unless dangerously-enable-passthrough is enabled"))
 	}
 	result = errors.Join(result, c.MetricsConfig.Check())
 	result = errors.Join(result, c.PprofConfig.Check())
@@ -109,6 +113,15 @@ func NewConfig(ctx *cli.Context, version string) (*Config, error) {
 		return nil, fmt.Errorf("validation-interval must be positive, got %s", validationInterval)
 	}
 
+	passthrough := ctx.Bool(flags.DangerouslyEnablePassthroughFlag.Name)
+	var allowedSenders *SenderPolicy
+	if ctx.IsSet(flags.AllowedSendersFlag.Name) {
+		allowedSenders, err = ParseSenderPolicy(ctx.String(flags.AllowedSendersFlag.Name))
+		if err != nil {
+			return nil, fmt.Errorf("invalid allowed-senders: %w", err)
+		}
+	}
+
 	// Load rollup configs from --networks and --rollup-configs
 	rollupConfigs, err := loadRollupConfigs(
 		ctx.StringSlice(flags.NetworksFlag.Name),
@@ -133,7 +146,8 @@ func NewConfig(ctx *cli.Context, version string) (*Config, error) {
 		Version:                     version,
 		PollInterval:                pollInterval,
 		ValidationInterval:          validationInterval,
-		Passthrough:                 ctx.Bool(flags.DangerouslyEnablePassthroughFlag.Name),
+		Passthrough:                 passthrough,
+		AllowedSenders:              allowedSenders,
 		LogConfig:                   oplog.ReadCLIConfig(ctx),
 		MetricsConfig:               opmetrics.ReadCLIConfig(ctx),
 		PprofConfig:                 oppprof.ReadCLIConfig(ctx),

--- a/op-interop-filter/filter/frontend.go
+++ b/op-interop-filter/filter/frontend.go
@@ -18,9 +18,9 @@ type QueryFrontend struct {
 
 // CheckAccessList validates interop executing messages
 func (f *QueryFrontend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error {
+	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor, sender common.Address) error {
 
-	err := f.backend.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor)
+	err := f.backend.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor, sender)
 	if err != nil {
 		return &rpc.JsonError{
 			Code:    types.GetErrorCode(err),

--- a/op-interop-filter/filter/frontend.go
+++ b/op-interop-filter/filter/frontend.go
@@ -18,7 +18,7 @@ type QueryFrontend struct {
 
 // CheckAccessList validates interop executing messages
 func (f *QueryFrontend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor, sender common.Address) error {
+	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor, sender *common.Address) error {
 
 	err := f.backend.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor, sender)
 	if err != nil {

--- a/op-interop-filter/filter/sender_policy.go
+++ b/op-interop-filter/filter/sender_policy.go
@@ -1,0 +1,60 @@
+package filter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// SenderPolicy controls which senders may submit interop transactions.
+type SenderPolicy struct {
+	allowAny bool
+	allowed  map[common.Address]struct{}
+}
+
+func ParseSenderPolicy(raw string) (*SenderPolicy, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, fmt.Errorf("allowed-senders must not be empty")
+	}
+	if raw == "*" {
+		return &SenderPolicy{allowAny: true}, nil
+	}
+
+	parts := strings.Split(raw, ",")
+	allowed := make(map[common.Address]struct{}, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, fmt.Errorf("allowed-senders contains an empty entry")
+		}
+		if part == "*" {
+			return nil, fmt.Errorf("allowed-senders wildcard '*' must be used by itself")
+		}
+		if !common.IsHexAddress(part) {
+			return nil, fmt.Errorf("invalid sender address %q", part)
+		}
+		allowed[common.HexToAddress(part)] = struct{}{}
+	}
+	return &SenderPolicy{allowed: allowed}, nil
+}
+
+func AllowAnySenderPolicy() *SenderPolicy {
+	return &SenderPolicy{allowAny: true}
+}
+
+func (p *SenderPolicy) Allows(sender common.Address) bool {
+	if p == nil {
+		return false
+	}
+	if p.allowAny {
+		return true
+	}
+	_, ok := p.allowed[sender]
+	return ok
+}
+
+func (p *SenderPolicy) AllowsAny() bool {
+	return p != nil && p.allowAny
+}

--- a/op-interop-filter/filter/sender_policy_test.go
+++ b/op-interop-filter/filter/sender_policy_test.go
@@ -1,0 +1,61 @@
+package filter
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func mustParseTestSenderPolicy(t *testing.T, raw string) *SenderPolicy {
+	t.Helper()
+
+	policy, err := ParseSenderPolicy(raw)
+	require.NoError(t, err)
+	return policy
+}
+
+func TestParseSenderPolicy(t *testing.T) {
+	t.Run("wildcard", func(t *testing.T) {
+		policy, err := ParseSenderPolicy("*")
+		require.NoError(t, err)
+		require.True(t, policy.AllowsAny())
+		require.True(t, policy.Allows(common.HexToAddress("0x1111111111111111111111111111111111111111")))
+	})
+
+	t.Run("comma separated addresses", func(t *testing.T) {
+		addrA := common.HexToAddress("0x1111111111111111111111111111111111111111")
+		addrB := common.HexToAddress("0x2222222222222222222222222222222222222222")
+		policy, err := ParseSenderPolicy(addrA.Hex() + "," + addrB.Hex())
+		require.NoError(t, err)
+		require.False(t, policy.AllowsAny())
+		require.True(t, policy.Allows(addrA))
+		require.True(t, policy.Allows(addrB))
+		require.False(t, policy.Allows(common.HexToAddress("0x3333333333333333333333333333333333333333")))
+	})
+
+	t.Run("rejects empty input", func(t *testing.T) {
+		_, err := ParseSenderPolicy("")
+		require.ErrorContains(t, err, "must not be empty")
+	})
+
+	t.Run("rejects invalid wildcard mix", func(t *testing.T) {
+		_, err := ParseSenderPolicy("*,0x1111111111111111111111111111111111111111")
+		require.ErrorContains(t, err, "must be used by itself")
+	})
+
+	t.Run("rejects invalid address", func(t *testing.T) {
+		_, err := ParseSenderPolicy("not-an-address")
+		require.ErrorContains(t, err, "invalid sender address")
+	})
+
+	t.Run("rejects empty entry", func(t *testing.T) {
+		_, err := ParseSenderPolicy("0x1111111111111111111111111111111111111111,")
+		require.ErrorContains(t, err, "empty entry")
+	})
+}
+
+func TestConfigCheck_RequiresAllowedSendersWithoutPassthrough(t *testing.T) {
+	cfg := &Config{Passthrough: false}
+	require.ErrorContains(t, cfg.Check(), "allowed-senders must be configured")
+}

--- a/op-interop-filter/filter/service.go
+++ b/op-interop-filter/filter/service.go
@@ -224,6 +224,7 @@ func (s *Service) initBackend(ctx context.Context, cfg *Config) error {
 		Chains:         chains,
 		CrossValidator: crossValidator,
 		Passthrough:    cfg.Passthrough,
+		SenderPolicy:   cfg.AllowedSenders,
 	})
 
 	s.log.Info("Created backend", "chains", len(chains))

--- a/op-interop-filter/flags/flags.go
+++ b/op-interop-filter/flags/flags.go
@@ -99,6 +99,12 @@ var (
 		EnvVars: prefixEnvVars("VALIDATION_INTERVAL"),
 		Value:   "500ms",
 	}
+	AllowedSendersFlag = &cli.StringFlag{
+		Name:    "allowed-senders",
+		Usage:   "Comma-separated allowed sender addresses, or '*' to accept any sender. Required unless dangerously-enable-passthrough is set.",
+		EnvVars: prefixEnvVars("ALLOWED_SENDERS"),
+		Value:   "",
+	}
 	DangerouslyEnablePassthroughFlag = &cli.BoolFlag{
 		Name:    "dangerously-enable-passthrough",
 		Usage:   "Allow all transactions through without interop filtering. DANGEROUS: disables all executing message validation.",
@@ -123,6 +129,7 @@ var optionalFlags = []cli.Flag{
 	RPCPortFlag,
 	PollIntervalFlag,
 	ValidationIntervalFlag,
+	AllowedSendersFlag,
 	DangerouslyEnablePassthroughFlag,
 }
 

--- a/op-service/apis/supervisor.go
+++ b/op-service/apis/supervisor.go
@@ -26,7 +26,7 @@ type SupervisorAdminAPI interface {
 
 type SupervisorQueryAPI interface {
 	CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-		minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor, sender common.Address) error
+		minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor, sender *common.Address) error
 	CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error)
 	LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
 	LocalSafe(ctx context.Context, chainID eth.ChainID) (result types.DerivedIDPair, err error)

--- a/op-service/apis/supervisor.go
+++ b/op-service/apis/supervisor.go
@@ -26,7 +26,7 @@ type SupervisorAdminAPI interface {
 
 type SupervisorQueryAPI interface {
 	CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-		minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error
+		minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor, sender common.Address) error
 	CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error)
 	LocalUnsafe(ctx context.Context, chainID eth.ChainID) (eth.BlockID, error)
 	LocalSafe(ctx context.Context, chainID eth.ChainID) (result types.DerivedIDPair, err error)

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -74,7 +74,7 @@ func (cl *SupervisorClient) GetFailsafeEnabled(ctx context.Context) (bool, error
 }
 
 func (cl *SupervisorClient) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor, sender common.Address) error {
+	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor, sender *common.Address) error {
 	return cl.client.CallContext(ctx, nil, "supervisor_checkAccessList", inboxEntries, minSafety, executingDescriptor, sender)
 }
 

--- a/op-service/sources/supervisor_client.go
+++ b/op-service/sources/supervisor_client.go
@@ -74,8 +74,8 @@ func (cl *SupervisorClient) GetFailsafeEnabled(ctx context.Context) (bool, error
 }
 
 func (cl *SupervisorClient) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error {
-	return cl.client.CallContext(ctx, nil, "supervisor_checkAccessList", inboxEntries, minSafety, executingDescriptor)
+	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor, sender common.Address) error {
+	return cl.client.CallContext(ctx, nil, "supervisor_checkAccessList", inboxEntries, minSafety, executingDescriptor, sender)
 }
 
 func (cl *SupervisorClient) CrossDerivedToSource(ctx context.Context, chainID eth.ChainID, derived eth.BlockID) (derivedFrom eth.BlockRef, err error) {

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -567,7 +567,7 @@ func (su *SupervisorBackend) checkSafety(chainID eth.ChainID, blockID eth.BlockI
 }
 
 func (su *SupervisorBackend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, execDescr types.ExecutingDescriptor, sender common.Address) error {
+	minSafety types.SafetyLevel, execDescr types.ExecutingDescriptor, sender *common.Address) error {
 	_ = sender
 	// Check if failsafe is enabled
 	if su.isFailsafeEnabled() {

--- a/op-supervisor/supervisor/backend/backend.go
+++ b/op-supervisor/supervisor/backend/backend.go
@@ -567,7 +567,8 @@ func (su *SupervisorBackend) checkSafety(chainID eth.ChainID, blockID eth.BlockI
 }
 
 func (su *SupervisorBackend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, execDescr types.ExecutingDescriptor) error {
+	minSafety types.SafetyLevel, execDescr types.ExecutingDescriptor, sender common.Address) error {
+	_ = sender
 	// Check if failsafe is enabled
 	if su.isFailsafeEnabled() {
 		su.logger.Debug("Failsafe is enabled, rejecting access-list check")

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -631,7 +631,7 @@ func TestFailsafeEnabled(t *testing.T) {
 	require.False(t, enabled, "failsafe should be disabled by default")
 
 	// Test that CheckAccessList works normally in initial state
-	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{}, common.Address{})
+	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{}, nil)
 	require.NoError(t, err, "CheckAccessList should work normally when failsafe is disabled")
 
 	// Test setting failsafe to true
@@ -642,7 +642,7 @@ func TestFailsafeEnabled(t *testing.T) {
 	require.True(t, enabled, "failsafe should be enabled after setting to true")
 
 	// Test that CheckAccessList returns ErrFailsafeEnabled when failsafe is enabled
-	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{}, common.Address{})
+	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{}, nil)
 	require.ErrorIs(t, err, types.ErrFailsafeEnabled, "CheckAccessList should return ErrFailsafeEnabled when failsafe is enabled")
 
 	// Test setting failsafe to false
@@ -653,7 +653,7 @@ func TestFailsafeEnabled(t *testing.T) {
 	require.False(t, enabled, "failsafe should be disabled after setting to false")
 
 	// Test that CheckAccessList works normally when failsafe is disabled
-	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{}, common.Address{})
+	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{}, nil)
 	require.NoError(t, err, "CheckAccessList should work normally when failsafe is disabled")
 }
 

--- a/op-supervisor/supervisor/backend/backend_test.go
+++ b/op-supervisor/supervisor/backend/backend_test.go
@@ -631,7 +631,7 @@ func TestFailsafeEnabled(t *testing.T) {
 	require.False(t, enabled, "failsafe should be disabled by default")
 
 	// Test that CheckAccessList works normally in initial state
-	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{})
+	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{}, common.Address{})
 	require.NoError(t, err, "CheckAccessList should work normally when failsafe is disabled")
 
 	// Test setting failsafe to true
@@ -642,7 +642,7 @@ func TestFailsafeEnabled(t *testing.T) {
 	require.True(t, enabled, "failsafe should be enabled after setting to true")
 
 	// Test that CheckAccessList returns ErrFailsafeEnabled when failsafe is enabled
-	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{})
+	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{}, common.Address{})
 	require.ErrorIs(t, err, types.ErrFailsafeEnabled, "CheckAccessList should return ErrFailsafeEnabled when failsafe is enabled")
 
 	// Test setting failsafe to false
@@ -653,7 +653,7 @@ func TestFailsafeEnabled(t *testing.T) {
 	require.False(t, enabled, "failsafe should be disabled after setting to false")
 
 	// Test that CheckAccessList works normally when failsafe is disabled
-	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{})
+	err = b.CheckAccessList(context.Background(), []common.Hash{}, types.LocalUnsafe, types.ExecutingDescriptor{}, common.Address{})
 	require.NoError(t, err, "CheckAccessList should work normally when failsafe is disabled")
 }
 

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -47,7 +47,8 @@ func (m *MockBackend) AddL2RPC(ctx context.Context, rpc string, jwtSecret eth.By
 }
 
 func (m *MockBackend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error {
+	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor, sender common.Address) error {
+	_ = sender
 	return nil
 }
 

--- a/op-supervisor/supervisor/backend/mock.go
+++ b/op-supervisor/supervisor/backend/mock.go
@@ -47,7 +47,7 @@ func (m *MockBackend) AddL2RPC(ctx context.Context, rpc string, jwtSecret eth.By
 }
 
 func (m *MockBackend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor, sender common.Address) error {
+	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor, sender *common.Address) error {
 	_ = sender
 	return nil
 }

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -24,8 +24,8 @@ type QueryFrontend struct {
 var _ apis.SupervisorQueryAPI = (*QueryFrontend)(nil)
 
 func (q *QueryFrontend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor) error {
-	err := q.Supervisor.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor)
+	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor, sender common.Address) error {
+	err := q.Supervisor.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor, sender)
 	if err != nil {
 		return &rpc.JsonError{
 			Code:    types.GetErrorCode(err),

--- a/op-supervisor/supervisor/frontend/frontend.go
+++ b/op-supervisor/supervisor/frontend/frontend.go
@@ -24,7 +24,7 @@ type QueryFrontend struct {
 var _ apis.SupervisorQueryAPI = (*QueryFrontend)(nil)
 
 func (q *QueryFrontend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash,
-	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor, sender common.Address) error {
+	minSafety types.SafetyLevel, executingDescriptor types.ExecutingDescriptor, sender *common.Address) error {
 	err := q.Supervisor.CheckAccessList(ctx, inboxEntries, minSafety, executingDescriptor, sender)
 	if err != nil {
 		return &rpc.JsonError{

--- a/op-supervisor/supervisor/service_test.go
+++ b/op-supervisor/supervisor/service_test.go
@@ -72,7 +72,7 @@ func TestSupervisorService(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		err = cl.CallContext(ctx, nil, "supervisor_checkAccessList",
 			[]common.Hash{}, types.CrossUnsafe, types.ExecutingDescriptor{
-				Timestamp: 1234568, ChainID: eth.ChainIDFromUInt64(123)})
+				Timestamp: 1234568, ChainID: eth.ChainIDFromUInt64(123)}, common.Address{})
 		cancel()
 		require.NoError(t, err)
 		cl.Close()

--- a/op-supervisor/supervisor/types/error.go
+++ b/op-supervisor/supervisor/types/error.go
@@ -46,6 +46,8 @@ var (
 	ErrUninitialized = errors.New("uninitialized chain database")
 	// ErrFailsafeEnabled is when failsafe is enabled and the request is rejected
 	ErrFailsafeEnabled = errors.New("failsafe is enabled, rejecting all CheckAccessList requests")
+	// ErrUnauthorizedSender is when the sender is not permitted to submit interop transactions.
+	ErrUnauthorizedSender = errors.New("sender not allowed")
 )
 
 var genericInvalidParamsErr = -32602
@@ -68,6 +70,7 @@ var errorCodeMap = map[error]int{
 
 	ErrNoRPCSource:             genericInvalidParamsErr,
 	ErrFailsafeEnabled:         genericInvalidParamsErr,
+	ErrUnauthorizedSender:      genericInvalidParamsErr,
 	ErrInvalidatedRead:         genericInvalidParamsErr,
 	ErrAlreadyInvalidatingRead: genericInvalidParamsErr,
 	ErrRewindFailed:            genericInvalidParamsErr,

--- a/rust/kona/tests/supervisor/pre_interop/pre_test.go
+++ b/rust/kona/tests/supervisor/pre_interop/pre_test.go
@@ -101,7 +101,7 @@ func TestPreNoInbox(gt *testing.T) {
 		accessEntries := []stypes.Access{execTrigger.Msg.Access()}
 		accessList := stypes.EncodeAccessList(accessEntries)
 
-		err = sys.Supervisor.Escape().QueryAPI().CheckAccessList(ctx, accessList, stypes.CrossSafe, ed)
+		err = sys.Supervisor.Escape().QueryAPI().CheckAccessList(ctx, accessList, stypes.CrossSafe, ed, common.Address{})
 		require.ErrorContains(err, "conflicting data")
 	}
 

--- a/rust/kona/tests/supervisor/pre_interop/pre_test.go
+++ b/rust/kona/tests/supervisor/pre_interop/pre_test.go
@@ -101,7 +101,7 @@ func TestPreNoInbox(gt *testing.T) {
 		accessEntries := []stypes.Access{execTrigger.Msg.Access()}
 		accessList := stypes.EncodeAccessList(accessEntries)
 
-		err = sys.Supervisor.Escape().QueryAPI().CheckAccessList(ctx, accessList, stypes.CrossSafe, ed, common.Address{})
+		err = sys.Supervisor.Escape().QueryAPI().CheckAccessList(ctx, accessList, stypes.CrossSafe, ed, nil)
 		require.ErrorContains(err, "conflicting data")
 	}
 

--- a/rust/op-reth/crates/txpool/src/supervisor/client.rs
+++ b/rust/op-reth/crates/txpool/src/supervisor/client.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use alloy_consensus::Transaction;
 use alloy_eips::eip2930::AccessList;
-use alloy_primitives::{B256, TxHash};
+use alloy_primitives::{Address, B256, TxHash};
 use alloy_rpc_client::ReqwestClient;
 use futures_util::{
     Stream,
@@ -64,11 +64,13 @@ impl SupervisorClient {
         &self,
         inbox_entries: &'a [B256],
         executing_descriptor: ExecutingDescriptor,
+        sender: Address,
     ) -> CheckAccessListRequest<'a> {
         CheckAccessListRequest {
             client: self.inner.client.clone(),
             inbox_entries: Cow::Borrowed(inbox_entries),
             executing_descriptor,
+            sender,
             timeout: self.inner.timeout,
             safety: self.inner.safety,
             metrics: self.inner.metrics.clone(),
@@ -88,6 +90,7 @@ impl SupervisorClient {
         &self,
         access_list: Option<&AccessList>,
         hash: &TxHash,
+        sender: Address,
         timestamp: u64,
         timeout: Option<u64>,
         is_interop_active: bool,
@@ -112,6 +115,7 @@ impl SupervisorClient {
             .check_access_list(
                 inbox_entries.as_slice(),
                 ExecutingDescriptor::new(self.inner.chain_id, timestamp, timeout),
+                sender,
             )
             .await
         {
@@ -151,6 +155,7 @@ impl SupervisorClient {
                     .is_valid_cross_tx(
                         tx_item.access_list(),
                         tx_item.hash(),
+                        tx_item.sender(),
                         current_timestamp,
                         Some(revalidation_window),
                         true,
@@ -245,6 +250,7 @@ pub struct CheckAccessListRequest<'a> {
     client: ReqwestClient,
     inbox_entries: Cow<'a, [B256]>,
     executing_descriptor: ExecutingDescriptor,
+    sender: Address,
     timeout: Duration,
     safety: SafetyLevel,
     metrics: SupervisorMetrics,
@@ -269,7 +275,8 @@ impl<'a> IntoFuture for CheckAccessListRequest<'a> {
     type IntoFuture = BoxFuture<'a, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
-        let Self { client, inbox_entries, executing_descriptor, timeout, safety, metrics } = self;
+        let Self { client, inbox_entries, executing_descriptor, sender, timeout, safety, metrics } =
+            self;
         Box::pin(async move {
             let start = Instant::now();
 
@@ -277,7 +284,7 @@ impl<'a> IntoFuture for CheckAccessListRequest<'a> {
                 timeout,
                 client.request(
                     "supervisor_checkAccessList",
-                    (inbox_entries, safety, executing_descriptor),
+                    (inbox_entries, safety, executing_descriptor, sender),
                 ),
             )
             .await;

--- a/rust/op-reth/crates/txpool/src/validator.rs
+++ b/rust/op-reth/crates/txpool/src/validator.rs
@@ -283,6 +283,7 @@ where
             .is_valid_cross_tx(
                 tx.access_list(),
                 tx.hash(),
+                tx.sender(),
                 self.block_info.timestamp.load(Ordering::Relaxed),
                 Some(TRANSACTION_VALIDITY_WINDOW_SECS),
                 self.fork_tracker.is_interop_activated(),


### PR DESCRIPTION
## Summary
Add sender-based allow-listing to the interop filter and thread the transaction sender through the shared `supervisor_checkAccessList` RPC.

## Included
- add `op-interop-filter` sender policy parsing for comma-separated addresses or `*`
- fail startup when passthrough is disabled and no sender policy is configured
- preserve passthrough precedence over all filtering
- extend the shared supervisor query API and RPC clients to include `sender`
- update in-repo caller/test/mocks, including `op-reth`
- add filter tests for allowed, rejected, and wildcard sender policy behavior

## Verification
- `go test ./op-interop-filter/filter ./op-supervisor/supervisor/... ./op-service/sources`
- `cargo check -p reth-optimism-txpool`
- `go test ./op-acceptance-tests/tests/interop/upgrade -run TestDoesNotExist -count=0`
- `go test ./rust/kona/tests/supervisor/pre_interop -run TestDoesNotExist -count=0`

## Notes
- `op-e2e/interop` compile-only verification is blocked in this workspace by missing `packages/contracts-bedrock/forge-artifacts`.
- `proxyd` in `infra/` is not included here because that checkout is not present in this workspace.