### PR TITLE
feat(op-reth): interop sender allow-list in txpool

### DIFF
--- a/rust/op-reth/crates/node/src/args.rs
+++ b/rust/op-reth/crates/node/src/args.rs
@@ -49,6 +49,13 @@ pub struct RollupArgs {
     )]
     pub supervisor_safety_level: SafetyLevel,
 
+    /// Comma-separated list of allowed sender addresses for interop (cross-chain) transactions.
+    /// When set, only transactions from these senders will be accepted as interop transactions;
+    /// interop transactions from any other sender are rejected. When not set, all interop
+    /// transactions are blocked by default.
+    #[arg(long = "rollup.interop-allowed-senders", value_delimiter = ',', value_name = "ADDRESSES")]
+    pub interop_allowed_senders: Vec<String>,
+
     /// Optional headers to use when connecting to the sequencer.
     #[arg(long = "rollup.sequencer-headers", requires = "sequencer")]
     pub sequencer_headers: Vec<String>,
@@ -151,6 +158,7 @@ impl Default for RollupArgs {
             enable_tx_conditional: false,
             supervisor_http: None,
             supervisor_safety_level: SafetyLevel::CrossUnsafe,
+            interop_allowed_senders: Vec::new(),
             sequencer_headers: Vec::new(),
             historical_rpc: None,
             min_suggested_priority_fee: 1_000_000,

--- a/rust/op-reth/crates/node/src/args.rs
+++ b/rust/op-reth/crates/node/src/args.rs
@@ -240,6 +240,34 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_interop_allowed_senders() {
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--rollup.interop-allowed-senders",
+            "0x1111111111111111111111111111111111111111,0x2222222222222222222222222222222222222222",
+        ])
+        .args;
+        assert_eq!(
+            args.interop_allowed_senders,
+            vec![
+                "0x1111111111111111111111111111111111111111",
+                "0x2222222222222222222222222222222222222222",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_interop_allowed_senders_wildcard() {
+        let args = CommandParser::<RollupArgs>::parse_from([
+            "reth",
+            "--rollup.interop-allowed-senders",
+            "*",
+        ])
+        .args;
+        assert_eq!(args.interop_allowed_senders, vec!["*"]);
+    }
+
+    #[test]
     fn test_parse_optimism_many_args() {
         let expected_args = RollupArgs {
             disable_txpool_gossip: true,

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -985,37 +985,29 @@ where
     ) -> eyre::Result<Self::Pool> {
         let Self { pool_config_overrides, interop_allowed_senders, .. } = self;
 
-        // Parse interop allowed senders.
-        //   - Not set (empty vec) → Some(empty set) → all interop txs blocked (fail closed)
-        //   - ["*"]               → None            → any sender allowed (explicit wildcard)
-        //   - ["0xABC", "0xDEF"]  → Some({ABC,DEF}) → only those senders
-        let allowed_interop_senders = if interop_allowed_senders.len() == 1
-            && interop_allowed_senders[0] == "*"
-        {
-            info!(target: "reth::cli",
-                "Interop sender allow-list set to wildcard (*), any sender may submit cross-chain transactions"
-            );
-            None
-        } else {
-            let mut senders = std::collections::HashSet::new();
-            for s in &interop_allowed_senders {
-                let addr: alloy_primitives::Address = s.parse().map_err(|_| {
-                    eyre::eyre!("invalid interop allowed sender address: {s}")
-                })?;
-                senders.insert(addr);
-            }
-            if senders.is_empty() {
+        let interop_sender_policy = reth_optimism_txpool::InteropSenderPolicy::parse(
+            &interop_allowed_senders,
+        )
+        .map_err(|e| eyre::eyre!(e))?;
+
+        match &interop_sender_policy {
+            reth_optimism_txpool::InteropSenderPolicy::BlockAll => {
                 info!(target: "reth::cli",
                     "No --rollup.interop-allowed-senders configured, all interop transactions will be rejected"
                 );
-            } else {
+            }
+            reth_optimism_txpool::InteropSenderPolicy::AllowList(set) => {
                 info!(target: "reth::cli",
-                    count = senders.len(),
+                    count = set.len(),
                     "Interop sender allow-list configured, only allowed senders may submit cross-chain transactions"
                 );
             }
-            Some(senders)
-        };
+            reth_optimism_txpool::InteropSenderPolicy::AllowAll => {
+                info!(target: "reth::cli",
+                    "Interop sender allow-list set to wildcard (*), any sender may submit cross-chain transactions"
+                );
+            }
+        }
 
         // supervisor used for interop txpool validation
         let supervisor_client = if let Some(url) = self.supervisor_http.clone() {
@@ -1054,7 +1046,7 @@ where
                         // In --dev mode we can't require gas fees because we're unable to decode
                         // the L1 block info
                         .require_l1_data_gas_fee(!ctx.config().dev.dev)
-                        .with_allowed_interop_senders(allowed_interop_senders.clone());
+                        .with_interop_sender_policy(interop_sender_policy.clone());
                     if let Some(client) = supervisor_client.clone() {
                         v = v.with_supervisor(client);
                     }

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -169,7 +169,8 @@ impl OpNode {
                     .with_supervisor(
                         self.args.supervisor_http.clone(),
                         self.args.supervisor_safety_level,
-                    ),
+                    )
+                    .with_interop_allowed_senders(self.args.interop_allowed_senders.clone()),
             )
             .payload(BasicPayloadServiceBuilder::new(
                 OpPayloadBuilder::new(compute_pending_block)
@@ -903,6 +904,8 @@ pub struct OpPoolBuilder<T = crate::txpool::OpPooledTransaction> {
     pub supervisor_http: Option<String>,
     /// Supervisor safety level
     pub supervisor_safety_level: SafetyLevel,
+    /// Allowed sender addresses for interop transactions (hex strings).
+    pub interop_allowed_senders: Vec<String>,
     /// Marker for the pooled transaction type.
     _pd: core::marker::PhantomData<T>,
 }
@@ -914,6 +917,7 @@ impl<T> Default for OpPoolBuilder<T> {
             enable_tx_conditional: false,
             supervisor_http: None,
             supervisor_safety_level: SafetyLevel::CrossUnsafe,
+            interop_allowed_senders: Vec::new(),
             _pd: Default::default(),
         }
     }
@@ -926,6 +930,7 @@ impl<T> Clone for OpPoolBuilder<T> {
             enable_tx_conditional: self.enable_tx_conditional,
             supervisor_http: self.supervisor_http.clone(),
             supervisor_safety_level: self.supervisor_safety_level,
+            interop_allowed_senders: self.interop_allowed_senders.clone(),
             _pd: core::marker::PhantomData,
         }
     }
@@ -957,6 +962,12 @@ impl<T> OpPoolBuilder<T> {
         self.supervisor_safety_level = supervisor_safety_level;
         self
     }
+
+    /// Sets the allowed sender addresses for interop transactions.
+    pub fn with_interop_allowed_senders(mut self, senders: Vec<String>) -> Self {
+        self.interop_allowed_senders = senders;
+        self
+    }
 }
 
 impl<Node, T, Evm> PoolBuilder<Node, Evm> for OpPoolBuilder<T>
@@ -972,7 +983,39 @@ where
         ctx: &BuilderContext<Node>,
         evm_config: Evm,
     ) -> eyre::Result<Self::Pool> {
-        let Self { pool_config_overrides, .. } = self;
+        let Self { pool_config_overrides, interop_allowed_senders, .. } = self;
+
+        // Parse interop allowed senders.
+        //   - Not set (empty vec) → Some(empty set) → all interop txs blocked (fail closed)
+        //   - ["*"]               → None            → any sender allowed (explicit wildcard)
+        //   - ["0xABC", "0xDEF"]  → Some({ABC,DEF}) → only those senders
+        let allowed_interop_senders = if interop_allowed_senders.len() == 1
+            && interop_allowed_senders[0] == "*"
+        {
+            info!(target: "reth::cli",
+                "Interop sender allow-list set to wildcard (*), any sender may submit cross-chain transactions"
+            );
+            None
+        } else {
+            let mut senders = std::collections::HashSet::new();
+            for s in &interop_allowed_senders {
+                let addr: alloy_primitives::Address = s.parse().map_err(|_| {
+                    eyre::eyre!("invalid interop allowed sender address: {s}")
+                })?;
+                senders.insert(addr);
+            }
+            if senders.is_empty() {
+                info!(target: "reth::cli",
+                    "No --rollup.interop-allowed-senders configured, all interop transactions will be rejected"
+                );
+            } else {
+                info!(target: "reth::cli",
+                    count = senders.len(),
+                    "Interop sender allow-list configured, only allowed senders may submit cross-chain transactions"
+                );
+            }
+            Some(senders)
+        };
 
         // supervisor used for interop txpool validation
         let supervisor_client = if let Some(url) = self.supervisor_http.clone() {
@@ -1007,15 +1050,15 @@ where
                 )
                 .build_with_tasks(ctx.task_executor().clone(), blob_store.clone())
                 .map(|validator| {
-                    let v = OpTransactionValidator::new(validator)
+                    let mut v = OpTransactionValidator::new(validator)
                         // In --dev mode we can't require gas fees because we're unable to decode
                         // the L1 block info
-                        .require_l1_data_gas_fee(!ctx.config().dev.dev);
+                        .require_l1_data_gas_fee(!ctx.config().dev.dev)
+                        .with_allowed_interop_senders(allowed_interop_senders.clone());
                     if let Some(client) = supervisor_client.clone() {
-                        v.with_supervisor(client)
-                    } else {
-                        v
+                        v = v.with_supervisor(client);
                     }
+                    v
                 });
 
         let final_pool_config = pool_config_overrides.apply(ctx.pool_config());

--- a/rust/op-reth/crates/txpool/src/error.rs
+++ b/rust/op-reth/crates/txpool/src/error.rs
@@ -11,6 +11,9 @@ pub enum InvalidCrossTx {
     /// Error cause by cross chain tx during not active interop hardfork
     #[error("cross chain tx is invalid before interop")]
     CrossChainTxPreInterop,
+    /// Sender is not in the interop allowed senders list
+    #[error("interop tx sender not allowed: {0}")]
+    SenderNotAllowed(alloy_primitives::Address),
 }
 
 impl PoolTransactionError for InvalidCrossTx {
@@ -18,6 +21,7 @@ impl PoolTransactionError for InvalidCrossTx {
         match self {
             Self::ValidationError(_) => false,
             Self::CrossChainTxPreInterop => true,
+            Self::SenderNotAllowed(_) => true,
         }
     }
 

--- a/rust/op-reth/crates/txpool/src/lib.rs
+++ b/rust/op-reth/crates/txpool/src/lib.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod validator;
-pub use validator::{OpL1BlockInfo, OpTransactionValidator};
+pub use validator::{InteropSenderPolicy, OpL1BlockInfo, OpTransactionValidator};
 
 pub mod conditional;
 pub mod supervisor;

--- a/rust/op-reth/crates/txpool/src/supervisor/access_list.rs
+++ b/rust/op-reth/crates/txpool/src/supervisor/access_list.rs
@@ -16,8 +16,16 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 use crate::supervisor::CROSS_L2_INBOX_ADDRESS;
-use alloy_eips::eip2930::AccessListItem;
+use alloy_eips::eip2930::{AccessList, AccessListItem};
 use alloy_primitives::B256;
+
+/// Returns `true` if the access list contains any cross-L2 inbox entries,
+/// indicating this is an interop transaction.
+pub fn has_interop_inbox_entries(access_list: &AccessList) -> bool {
+    parse_access_list_items_to_inbox_entries(access_list.iter())
+        .next()
+        .is_some()
+}
 
 /// Parses [`AccessListItem`]s to inbox entries.
 ///

--- a/rust/op-reth/crates/txpool/src/supervisor/mod.rs
+++ b/rust/op-reth/crates/txpool/src/supervisor/mod.rs
@@ -1,6 +1,6 @@
 //! Supervisor support for interop
 mod access_list;
-pub use access_list::parse_access_list_items_to_inbox_entries;
+pub use access_list::{has_interop_inbox_entries, parse_access_list_items_to_inbox_entries};
 pub use op_alloy_consensus::interop::*;
 
 pub mod client;

--- a/rust/op-reth/crates/txpool/src/validator.rs
+++ b/rust/op-reth/crates/txpool/src/validator.rs
@@ -1,6 +1,6 @@
 use crate::{
     InvalidCrossTx, OpPooledTx,
-    supervisor::{SupervisorClient, parse_access_list_items_to_inbox_entries},
+    supervisor::{SupervisorClient, has_interop_inbox_entries},
 };
 use alloy_consensus::{BlockHeader, Transaction};
 use alloy_primitives::Address;
@@ -26,6 +26,49 @@ use std::{
         atomic::{AtomicBool, AtomicU64, Ordering},
     },
 };
+
+/// Policy for which senders are allowed to submit interop (cross-chain) transactions.
+#[derive(Debug, Clone)]
+pub enum InteropSenderPolicy {
+    /// All interop transactions are rejected (default, fail-closed).
+    BlockAll,
+    /// Only these senders may submit interop transactions.
+    AllowList(Arc<HashSet<Address>>),
+    /// Any sender may submit interop transactions (explicit wildcard).
+    AllowAll,
+}
+
+impl InteropSenderPolicy {
+    /// Returns `true` if the given sender is allowed to submit interop transactions.
+    pub fn allows(&self, sender: &Address) -> bool {
+        match self {
+            Self::BlockAll => false,
+            Self::AllowList(set) => set.contains(sender),
+            Self::AllowAll => true,
+        }
+    }
+
+    /// Parse from CLI flag values.
+    ///   - Empty vec → `BlockAll` (fail closed)
+    ///   - `["*"]` → `AllowAll` (explicit wildcard)
+    ///   - `["0xABC", "0xDEF"]` → `AllowList({ABC, DEF})`
+    pub fn parse(raw: &[String]) -> Result<Self, String> {
+        if raw.is_empty() {
+            return Ok(Self::BlockAll);
+        }
+        if raw.len() == 1 && raw[0] == "*" {
+            return Ok(Self::AllowAll);
+        }
+        let senders = raw
+            .iter()
+            .map(|s| {
+                s.parse::<Address>()
+                    .map_err(|_| format!("invalid interop allowed sender address: {s}"))
+            })
+            .collect::<Result<HashSet<_>, _>>()?;
+        Ok(Self::AllowList(Arc::new(senders)))
+    }
+}
 
 /// The interval for which we check transaction against supervisor, 1 hour.
 const TRANSACTION_VALIDITY_WINDOW_SECS: u64 = 3600;
@@ -61,10 +104,8 @@ pub struct OpTransactionValidator<Client, Tx, Evm> {
     supervisor_client: Option<SupervisorClient>,
     /// tracks activated forks relevant for transaction validation
     fork_tracker: Arc<OpForkTracker>,
-    /// Allowed sender addresses for interop transactions. If non-empty, only these senders
-    /// may submit interop (cross-chain) transactions. If empty, all interop transactions
-    /// are rejected.
-    allowed_interop_senders: Option<Arc<HashSet<Address>>>,
+    /// Policy for which senders may submit interop transactions.
+    interop_sender_policy: InteropSenderPolicy,
 }
 
 impl<Client, Tx, Evm> OpTransactionValidator<Client, Tx, Evm> {
@@ -135,7 +176,7 @@ where
             require_l1_data_gas_fee: true,
             supervisor_client: None,
             fork_tracker: Arc::new(OpForkTracker { interop: AtomicBool::from(false) }),
-            allowed_interop_senders: None,
+            interop_sender_policy: InteropSenderPolicy::BlockAll,
         }
     }
 
@@ -145,15 +186,9 @@ where
         self
     }
 
-    /// Set the allowed interop senders. When set, only these senders may submit interop
-    /// (cross-chain) transactions. When set to an empty set, all interop transactions are
-    /// rejected. When `None`, no sender filtering is applied (interop txs from any sender are
-    /// allowed through to supervisor validation).
-    pub fn with_allowed_interop_senders(
-        mut self,
-        allowed_senders: Option<HashSet<Address>>,
-    ) -> Self {
-        self.allowed_interop_senders = allowed_senders.map(Arc::new);
+    /// Set the interop sender policy.
+    pub fn with_interop_sender_policy(mut self, policy: InteropSenderPolicy) -> Self {
+        self.interop_sender_policy = policy;
         self
     }
 
@@ -214,17 +249,11 @@ where
             );
         }
 
-        // Interop sender allow-list check: if configured, only allowed senders may submit
-        // cross-chain transactions. This check runs locally before the supervisor RPC call.
-        if let Some(ref allowed_senders) = self.allowed_interop_senders {
-            let is_interop_tx = transaction
-                .access_list()
-                .is_some_and(|al| {
-                    parse_access_list_items_to_inbox_entries(al.iter())
-                        .next()
-                        .is_some()
-                });
-            if is_interop_tx && !allowed_senders.contains(transaction.sender_ref()) {
+        // Interop sender allow-list check: runs locally before the supervisor RPC call.
+        if let Some(access_list) = transaction.access_list() {
+            if has_interop_inbox_entries(access_list)
+                && !self.interop_sender_policy.allows(transaction.sender_ref())
+            {
                 let sender = *transaction.sender_ref();
                 return TransactionValidationOutcome::Invalid(
                     transaction,

--- a/rust/op-reth/crates/txpool/src/validator.rs
+++ b/rust/op-reth/crates/txpool/src/validator.rs
@@ -1,5 +1,9 @@
-use crate::{InvalidCrossTx, OpPooledTx, supervisor::SupervisorClient};
+use crate::{
+    InvalidCrossTx, OpPooledTx,
+    supervisor::{SupervisorClient, parse_access_list_items_to_inbox_entries},
+};
 use alloy_consensus::{BlockHeader, Transaction};
+use alloy_primitives::Address;
 use op_revm::L1BlockInfo;
 use parking_lot::RwLock;
 use reth_chainspec::ChainSpecProvider;
@@ -15,9 +19,12 @@ use reth_transaction_pool::{
     EthPoolTransaction, EthTransactionValidator, TransactionOrigin, TransactionValidationOutcome,
     TransactionValidator, error::InvalidPoolTransactionError,
 };
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, AtomicU64, Ordering},
+use std::{
+    collections::HashSet,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
 };
 
 /// The interval for which we check transaction against supervisor, 1 hour.
@@ -54,6 +61,10 @@ pub struct OpTransactionValidator<Client, Tx, Evm> {
     supervisor_client: Option<SupervisorClient>,
     /// tracks activated forks relevant for transaction validation
     fork_tracker: Arc<OpForkTracker>,
+    /// Allowed sender addresses for interop transactions. If non-empty, only these senders
+    /// may submit interop (cross-chain) transactions. If empty, all interop transactions
+    /// are rejected.
+    allowed_interop_senders: Option<Arc<HashSet<Address>>>,
 }
 
 impl<Client, Tx, Evm> OpTransactionValidator<Client, Tx, Evm> {
@@ -124,12 +135,25 @@ where
             require_l1_data_gas_fee: true,
             supervisor_client: None,
             fork_tracker: Arc::new(OpForkTracker { interop: AtomicBool::from(false) }),
+            allowed_interop_senders: None,
         }
     }
 
     /// Set the supervisor client and safety level
     pub fn with_supervisor(mut self, supervisor_client: SupervisorClient) -> Self {
         self.supervisor_client = Some(supervisor_client);
+        self
+    }
+
+    /// Set the allowed interop senders. When set, only these senders may submit interop
+    /// (cross-chain) transactions. When set to an empty set, all interop transactions are
+    /// rejected. When `None`, no sender filtering is applied (interop txs from any sender are
+    /// allowed through to supervisor validation).
+    pub fn with_allowed_interop_senders(
+        mut self,
+        allowed_senders: Option<HashSet<Address>>,
+    ) -> Self {
+        self.allowed_interop_senders = allowed_senders.map(Arc::new);
         self
     }
 
@@ -188,6 +212,27 @@ where
                 transaction,
                 InvalidTransactionError::TxTypeNotSupported.into(),
             );
+        }
+
+        // Interop sender allow-list check: if configured, only allowed senders may submit
+        // cross-chain transactions. This check runs locally before the supervisor RPC call.
+        if let Some(ref allowed_senders) = self.allowed_interop_senders {
+            let is_interop_tx = transaction
+                .access_list()
+                .is_some_and(|al| {
+                    parse_access_list_items_to_inbox_entries(al.iter())
+                        .next()
+                        .is_some()
+                });
+            if is_interop_tx && !allowed_senders.contains(transaction.sender_ref()) {
+                let sender = *transaction.sender_ref();
+                return TransactionValidationOutcome::Invalid(
+                    transaction,
+                    InvalidPoolTransactionError::Other(Box::new(
+                        InvalidCrossTx::SenderNotAllowed(sender),
+                    )),
+                );
+            }
         }
 
         // Interop cross tx validation


### PR DESCRIPTION
## Summary

- Adds `--rollup.interop-allowed-senders` CLI flag to op-reth that gates which addresses may submit interop (cross-chain) transactions
- The check runs **locally** in the txpool validator before the supervisor RPC call — no network boundary, higher confidence
- Only interop transactions are affected; non-interop txs are completely unaffected

**Behavior:**
- Flag not set → all interop txs rejected (fail closed)
- `--rollup.interop-allowed-senders=*` → any sender allowed (explicit wildcard)
- `--rollup.interop-allowed-senders=0xABC,0xDEF` → only those senders

**4 files, +111/-11 lines:**
- `args.rs` — new CLI flag
- `node.rs` — parse flag, plumb through builder
- `validator.rs` — sender check before supervisor RPC
- `error.rs` — `SenderNotAllowed` error variant

## Test plan

- [x] `cargo build -p reth-optimism-node -p reth-optimism-txpool` compiles clean
- [x] `cargo test -p reth-optimism-txpool` all tests pass
- [x] `cargo test -p reth-optimism-node` passes (1 pre-existing port conflict failure unrelated)
- [ ] Integration test with op-reth binary + interop-filter-utils spammer
- [ ] Unit tests for sender allow-list logic in validator.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)