### PR TITLE
fix(op-supernode): match op-node L1 HTTP poll interval default (12s)

### DIFF
--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -368,7 +368,7 @@ func (s *Supernode) initL1Client(ctx context.Context, cfg *config.CLIConfig) err
 	// Enable HTTP polling for L1 heads to support HTTP-only L1 connections (e.g., in tests)
 	l1RPC, err := client.NewRPC(ctx, s.log, cfg.L1NodeAddr,
 		client.WithDialAttempts(10),
-		client.WithHttpPollInterval(time.Second*2), // Poll every 2 seconds for HTTP connections
+		client.WithHttpPollInterval(time.Second*12), // Match op-node default (12s = L1 block time)
 	)
 	if err != nil {
 		return fmt.Errorf("failed to dial L1 address (%s): %w", cfg.L1NodeAddr, err)


### PR DESCRIPTION
## Summary
- Changes the supernode's L1 HTTP poll interval from 2s to 12s to match the op-node default
- L1 blocks only arrive every 12 seconds, so polling at 2s is 6x more frequent than needed
- With multiple virtual nodes each creating independent L1 head subscriptions via the shared PollingClient, the aggressive interval caused 2-3x more L1 RPC requests than equivalent separate op-node deployments

## Evidence
Measured over a multi-day benchmark comparing supernode vs 2x separate op-nodes syncing OP Mainnet + Unichain:
- **Mainnet**: supernode made 1.9x more L1 requests (210K vs 110K)
- **Sepolia**: supernode made 2.6x more L1 requests (53K vs 17K)
- The excess is almost entirely `eth_getBlockByNumber` calls from the 2s polling interval
- The `PollingClient` does deduplicate head subscriptions across virtual nodes (single `pollHeads()` goroutine fans out), but the 2s base rate is still 6x higher than the op-node default of 12s

## Test plan
- [x] Verified op-node default is 12s (`op-node/flags/flags.go:202`)
- [ ] Run supernode with the fix and measure L1 request rate reduction
- [ ] Verify no degradation in L1 head tracking latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)